### PR TITLE
build(deps): bump pytest 8.3.4 -> 9.0.3 + pytest-asyncio 0.24.0 -> 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ jinja2==3.1.6
 aiofiles==24.1.0
 yara-python==4.5.0
 pysigma>=1.2.0
-pytest==8.3.4
-pytest-asyncio==0.24.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
 httpx==0.28.1


### PR DESCRIPTION
## Summary

Coordinated bump of `pytest` and `pytest-asyncio`. Replaces Dependabot [#16](https://github.com/im40percentgit/shaferhund/pull/16) which was closed because it bumped only `pytest` and would've broken the `pytest-asyncio==0.24.0` pin (hard-capped at `pytest<9,>=8.2`).

## Changes

```diff
-pytest==8.3.4
-pytest-asyncio==0.24.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
```

## Why bump pytest

- **CVE-2025-71176**: fixes insecure temp directory usage (9.0.3)
- `config.inicfg` breaking change in 9.0.0 is restored via compat shim (deprecated in 9.1, removed in 10) — not used here
- `terminalprogress` feature disabled by default in 9.0.2 — no impact on this repo

## Why bump pytest-asyncio

- `0.24.0` hard-caps at `pytest<9`. Without this bump, PR #16 (and any future pytest-9 bump) can't install.
- `1.3.0` supports `pytest<10,>=8.2` — works with both pytest 8 and 9 so the repo isn't pinned to a specific pytest-major going forward.

## Test plan

Ran the full test suite in a fresh Python 3.12 venv with the new pins:

```
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
plugins: asyncio-1.3.0, anyio-4.13.0
collected 87 items

...
======================== 87 passed, 5 warnings in 0.81s ========================
```

- [x] `pip install -r requirements.txt` resolves cleanly (no dependency conflicts)
- [x] All 87 tests pass under pytest 9.0.3 + pytest-asyncio 1.3.0
- [x] 5 warnings are pre-existing Starlette `TemplateResponse` deprecation warnings, unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)