### PR TITLE
fix(security): loopback-bind Wazuh ports; move API creds to env (CSO F1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ ANTHROPIC_API_KEY=
 # Dashboard auth — unset binds the dashboard to 127.0.0.1 only (safe default)
 SHAFERHUND_TOKEN=
 
+# Wazuh manager REST API credentials.
+# The default upstream password is well-known; set your own before first start.
+WAZUH_API_USERNAME=wazuh-wui
+WAZUH_API_PASSWORD=REPLACE_ME_BEFORE_FIRST_START
+
 # Claude model selection
 CLAUDE_MODEL=claude-opus-4-5
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Shaferhund is a self-hosted alert triage agent for the solo security engineer pr
 ```
 1. cp .env.example .env
 2. Fill in ANTHROPIC_API_KEY (and SHAFERHUND_TOKEN if binding to non-localhost)
-3. podman compose up   (or: docker compose up)
-4. Open http://localhost:8000
+3. Set WAZUH_API_PASSWORD to a strong unique value — the placeholder must be replaced before first start.
+4. podman compose up   (or: docker compose up)
+5. Open http://localhost:8000
 ```
 
 Wazuh Manager starts first. Once its healthcheck passes, the shaferhund agent comes up alongside Suricata. The first cluster should appear on the dashboard within a few minutes of the Wazuh manager generating alerts.

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,14 +13,29 @@
 #   updates deferred to Phase 3.
 #
 # Required env vars (pass via .env or shell):
-#   ANTHROPIC_API_KEY  — Claude API key for triage
-#   SHAFERHUND_TOKEN   — optional; unset = localhost-only binding
+#   ANTHROPIC_API_KEY      — Claude API key for triage
+#   SHAFERHUND_TOKEN       — optional; unset = localhost-only binding
+#   WAZUH_API_USERNAME     — Wazuh REST API username (see .env.example)
+#   WAZUH_API_PASSWORD     — Wazuh REST API password (see .env.example)
 #
 # Usage:
 #   cp .env.example .env && edit .env
 #   docker compose up -d   (or: podman compose up -d)
 
 services:
+  # @decision DEC-SECURITY-001
+  # @title Wazuh manager ports bound to 127.0.0.1; API credentials via env vars
+  # @status accepted
+  # @rationale Binding to 0.0.0.0 (the Docker default) exposes the Wazuh REST
+  #   API (55000), agent-registration (1514/1515), and syslog (514/udp) on every
+  #   host interface. The default upstream password is publicly documented, so
+  #   any reachable host can authenticate and gain full control of the detection
+  #   pipeline. Loopback binding is safe for the default single-host deployment
+  #   where shaferhund-agent talks to the Wazuh manager over the Docker bridge
+  #   network (not via the host-side published port). Operators who run external
+  #   Wazuh agents on separate machines MUST change the 127.0.0.1: prefix to
+  #   their management interface IP (e.g. "10.0.0.1:1514:1514") in compose.yaml
+  #   and set a strong WAZUH_API_PASSWORD in .env.
   wazuh.manager:
     image: wazuh/wazuh-manager:4.9.2
     hostname: wazuh.manager
@@ -40,16 +55,16 @@ services:
         soft: 655360
         hard: 655360
     ports:
-      - "1514:1514"
-      - "1515:1515"
-      - "514:514/udp"
-      - "55000:55000"
+      - "127.0.0.1:1514:1514"
+      - "127.0.0.1:1515:1515"
+      - "127.0.0.1:514:514/udp"
+      - "127.0.0.1:55000:55000"
     environment:
       - WAZUH_NODE_NAME=manager
       - WAZUH_CLUSTER_NODES=wazuh.manager
       - WAZUH_CLUSTER_BIND_ADDR=wazuh.manager
-      - API_USERNAME=wazuh-wui
-      - API_PASSWORD=MyS3cr37P450r.*-
+      - API_USERNAME=${WAZUH_API_USERNAME}
+      - API_PASSWORD=${WAZUH_API_PASSWORD}
     volumes:
       - wazuh_api_configuration:/var/ossec/api/configuration
       - wazuh_etc:/var/ossec/etc


### PR DESCRIPTION
## Summary
- Wazuh manager API was reachable on 0.0.0.0:55000 with the well-known upstream default password committed in compose.yaml. Attackers on any reachable network could authenticate and control detection rules, agents, and active-response.
- Loopback-bind all four wazuh.manager ports (55000, 1514, 1515, 514/udp).
- Replace hardcoded `API_USERNAME` / `API_PASSWORD` with `${WAZUH_API_*}` env interpolation; add placeholder to `.env.example` with fail-loud default; update README Quickstart.
- `@decision DEC-SECURITY-001` added above `wazuh.manager` explaining the default and how multi-host operators restore agent reachability.

## Test plan
- [x] `grep MyS3cr37 compose.yaml` returns no matches
- [x] All 4 ports show `127.0.0.1:` prefix
- [x] `podman-compose config` parses cleanly
- [x] `pytest tests/` — 87 passed, 0 failures
- [ ] Manual: single-host `docker compose up` with `.env` set boots the stack
- [ ] Manual: port 55000 is NOT reachable from another host

## Notes
- This is 1 of 5 findings from a `/cso` security audit. F2–F5 will ship as separate PRs.
- **Do not auto-merge.** Leaving open for review.
- Breaking change for multi-host Wazuh setups: external agents will lose reachability until the `127.0.0.1:` prefix is removed. Documented in the `@decision` block and compose.yaml comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)