### PR TITLE
fix(security): drop ?token= query-param auth (CSO F2)

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -13,7 +13,7 @@ Background task lifecycle:
 
 Auth:
   - If SHAFERHUND_TOKEN is set, every non-health request requires
-    Authorization: Bearer <token> or the ?token=<token> query param.
+    Authorization: Bearer <token>.
   - If SHAFERHUND_TOKEN is unset, the server binds to 127.0.0.1 only
     (set via the uvicorn --host flag in __main__ / compose entrypoint).
 
@@ -23,6 +23,18 @@ Auth:
 @rationale Simple token is sufficient for a single-user local deployment.
            Unset token = localhost-only is safer than unset token = open.
            No session management needed at this scale.
+
+@decision DEC-AUTH-002
+@title Query-param token fallback removed
+@status accepted
+@rationale The former ?token=<token> query-param fallback was removed 2026-04-22
+           after CSO Finding 2. Query-string tokens leak into: uvicorn access
+           logs, reverse-proxy logs, browser history, browser URL bar, and the
+           Referer header on outbound navigation. Bearer-only keeps the secret
+           in the Authorization header, which is not logged by default and is
+           not sent as a Referer. If a shareable-link workflow is ever needed,
+           implement a one-time /login?token=... handler that sets a signed
+           cookie and immediately redirects, stripping the query string.
 
 @decision DEC-TAILER-001
 @title Dual independent tailer tasks feeding a single shared AlertClusterer
@@ -155,10 +167,14 @@ _bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def _require_auth(
-    request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
 ) -> None:
-    """FastAPI dependency: enforce token auth when SHAFERHUND_TOKEN is set."""
+    """FastAPI dependency: enforce bearer token auth when SHAFERHUND_TOKEN is set.
+
+    Accepts only the Authorization: Bearer <token> header.
+    The former ?token=<query-param> fallback was removed (DEC-AUTH-002) because
+    query-string tokens leak into access logs, browser history, and Referer headers.
+    """
     token = _settings.shaferhund_token if _settings else ""
     if not token:
         return  # No token configured — localhost-only binding is the guard
@@ -166,8 +182,6 @@ def _require_auth(
     provided = None
     if credentials and credentials.scheme.lower() == "bearer":
         provided = credentials.credentials
-    if not provided:
-        provided = request.query_params.get("token")
 
     if provided != token:
         raise HTTPException(

--- a/tests/test_deploy_undo.py
+++ b/tests/test_deploy_undo.py
@@ -12,13 +12,17 @@ Test cases:
      file but returns 409 (no un-reverted event to stamp). Documented choice:
      409 signals "file was present and deleted but no audit row to update" so
      callers know the state is partially inconsistent and can investigate.
+  5. Query-param token rejected — ?token=<correct> with no Authorization header
+     → 401 (DEC-AUTH-002: query-param fallback removed to prevent token leakage
+     via logs, browser history, and Referer headers).
 
 @decision DEC-UNDO-002
-@title test_deploy_undo covers happy path, auth, missing-file, already-reverted
+@title test_deploy_undo covers happy path, auth, missing-file, already-reverted, query-param-rejected
 @status accepted
 @rationale Real DB (in-memory), real file I/O via tmp_path, no internal mocks.
            External boundary (auth dependency) exercised via HTTP headers.
-           Four cases cover the four observable states of the undo endpoint.
+           Five cases cover the four observable states of the undo endpoint plus
+           regression coverage for the removed ?token= query-param fallback.
 """
 
 from pathlib import Path
@@ -282,6 +286,52 @@ def test_undo_deploy_already_reverted(tmp_path):
     assert resp.status_code == 409, f"Expected 409, got {resp.status_code}: {resp.text}"
     # File should be gone (we delete before checking the audit row)
     assert not rule_file.exists(), "File should still be deleted in the 409 path"
+
+    main_module._db = orig_db
+    main_module._settings = orig_settings
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Case 5: Query-param token rejected — ?token=<correct> → 401 (DEC-AUTH-002)
+# ---------------------------------------------------------------------------
+
+
+def test_query_param_token_rejected(tmp_path):
+    """?token=<correct-token> with no Authorization header must return 401.
+
+    The former query-param fallback was removed (DEC-AUTH-002) to prevent token
+    leakage via uvicorn access logs, browser history, and Referer headers.
+    Only Authorization: Bearer <token> is accepted.
+    """
+    db_path = str(tmp_path / "test.db")
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    token = "secret-token"
+    rule_id = "rule-qp-reject-001"
+
+    client, conn, _settings, (orig_db, orig_settings, main_module) = _make_app(
+        db_path, str(rules_dir), token=token
+    )
+
+    _seed_cluster(conn)
+    _seed_rule(conn, rule_id)
+    _seed_deploy_event(conn, rule_id)
+
+    rule_file = rules_dir / f"{rule_id}.yar"
+    rule_file.write_text("content")
+
+    # Correct token supplied only as a query param — must be rejected
+    resp = client.post(
+        f"/rules/{rule_id}/undo-deploy",
+        params={"token": token},
+    )
+
+    assert resp.status_code == 401, (
+        f"Expected 401 when token is in query param only, got {resp.status_code}: {resp.text}"
+    )
+    # No state change — file must still exist
+    assert rule_file.exists(), "Rule file must not be deleted when auth via query-param is rejected"
 
     main_module._db = orig_db
     main_module._settings = orig_settings


### PR DESCRIPTION
## Summary
- The auth dependency accepted the session token via `?token=<token>` URL query param alongside the proper `Authorization: Bearer` header.
- Query-string secrets leak to uvicorn access logs, upstream proxy logs, browser URL bar, browser history, and the `Referer` header. Any place that logs or retains URLs now becomes a credential archive.
- Removed the query-param fallback entirely. `_require_auth` is now bearer-only.
- Added negative unit test: correct token in `?token=` with no `Authorization` header must 401.
- Added `@decision DEC-AUTH-002` documenting the removal rationale.

## Test plan
- [x] `grep query_params.get\(\"token\"\) agent/` → no matches
- [x] `pytest tests/` — 88 passed, 0 failures (87 pre-existing + 1 new)
- [x] Live HTTP: `?token=<correct>` → 401, `Authorization: Bearer <correct>` → 200, no-auth → 401
- [ ] Manual: confirm existing operators have updated any personal scripts/bookmarks that used the `?token=` form

## Notes
- This is 2 of 5 findings from a `/cso` security audit. F1 shipped as PR #18; F3–F5 to follow.
- **Do not auto-merge.** Leaving open for review.
- Small behavior change: any existing bookmark or script that hit the dashboard with `?token=...` will 401. Users should migrate to the bearer header. Not a runtime regression; all HTMX calls in the templates already use relative URLs and inherit the browser's origin state — they never relied on query-param auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)