### PR TITLE
fix(security): split /health (public) and /metrics (authed) (CSO F5)

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -183,14 +183,47 @@ def _require_auth(
 
 @app.get("/health")
 async def health() -> JSONResponse:
-    """Poller status, queue depth, last triage timestamp, orchestrator stats, auto-deploy counts.
+    """Minimal liveness probe — status and poller health only.
 
     Always returns 200 — even if the tailer is degraded — so container
     health checks don't cycle the service on transient read errors.
 
-    New fields (Phase 2, REQ-P1-P2-004):
-      orchestrator — in-memory counters from the Claude tool-use loop.
-      auto_deploy  — 24h deploy/skip/revert counts from deploy_events.
+    Minimal — by design — so unauthenticated container probes can't be used
+    for reconnaissance. See ``/metrics`` for full operational stats.
+
+    @decision DEC-HEALTH-002
+    @title Split /health (public liveness) and /metrics (authenticated stats) per CSO F5
+    @status accepted
+    @rationale Public /health was returning queue depth, alert counts, timestamps,
+               and orchestrator counters — enough for an attacker to map the
+               deployment's workload and timing. Moving stats behind auth (when
+               SHAFERHUND_TOKEN is set) limits exposure without breaking container
+               probes, which only need {status, poller_healthy} to decide liveness.
+    """
+    return JSONResponse({
+        "status": "ok",
+        "poller_healthy": _poller_healthy,
+    })
+
+
+@app.get("/metrics", dependencies=[Depends(_require_auth)])
+async def metrics() -> JSONResponse:
+    """Authenticated operational stats. Migration from /health per CSO F5.
+
+    Requires ``Authorization: Bearer <token>`` (or ``?token=<token>``) when
+    ``SHAFERHUND_TOKEN`` is set. Returns 401 if auth fails; 200 with full
+    payload otherwise. When ``SHAFERHUND_TOKEN`` is unset the endpoint is
+    open, consistent with the localhost-only binding that replaces auth in
+    that mode.
+
+    Fields:
+      queue_depth, calls_this_hour, hourly_budget — triage queue state.
+      last_poll_at, last_triage_at               — activity timestamps.
+      total_alerts, total_clusters, pending_triage — DB aggregate counts.
+      orchestrator                               — in-memory counters from
+                                                   the Claude tool-use loop.
+      auto_deploy                                — 24h deploy/skip/revert
+                                                   counts from deploy_events.
     """
     stats = get_stats(_db) if _db else {}
 
@@ -205,9 +238,6 @@ async def health() -> JSONResponse:
         deployed_24h = skipped_24h = reverted_24h = 0
 
     return JSONResponse({
-        # Phase 1 fields — unchanged
-        "status": "ok",
-        "poller_healthy": _poller_healthy,
         "queue_depth": _triage_queue.depth if _triage_queue else 0,
         "calls_this_hour": _triage_queue.calls_this_hour if _triage_queue else 0,
         "hourly_budget": _settings.triage_hourly_budget if _settings else 0,
@@ -216,9 +246,9 @@ async def health() -> JSONResponse:
         "total_alerts": stats.get("total_alerts", 0),
         "total_clusters": stats.get("total_clusters", 0),
         "pending_triage": stats.get("pending_triage", 0),
-        # Phase 2 — orchestrator in-memory stats
+        # Orchestrator in-memory stats (Phase 2, REQ-P1-P2-004)
         "orchestrator": get_orchestrator_stats(),
-        # Phase 2 — auto-deploy 24h window counts
+        # Auto-deploy 24h window counts (Phase 2, REQ-P1-P2-004)
         "auto_deploy": {
             "enabled": bool(_settings.AUTO_DEPLOY_ENABLED) if _settings else False,
             "deployed_last_24h": deployed_24h,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ jinja2==3.1.6
 aiofiles==24.1.0
 yara-python==4.5.0
 pysigma>=1.2.0
-pytest==8.3.4
-pytest-asyncio==0.24.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
 httpx==0.28.1

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,13 +1,22 @@
 """
-/health endpoint tests — Phase 2, REQ-P1-P2-004.
+/health and /metrics endpoint tests — CSO F5 split.
 
-Verifies that:
-  1. Phase 1 fields are still present and correct (no regression).
-  2. New ``orchestrator`` block exists with the four expected keys/types.
-  3. New ``auto_deploy`` block exists with the four expected keys/types.
-  4. auto_deploy counts reflect seeded deploy_events data (24h window filter).
-  5. orchestrator counters increment correctly after a mock run_triage_loop call.
-  6. Zero-state: fresh DB + no runs → all counts 0, avg=0.0 (no divide-by-zero).
+/health (unauthenticated liveness probe):
+  1. Returns exactly {status, poller_healthy} — no extra keys.
+  2. Always returns 200 regardless of token configuration.
+  3. Rich recon fields (queue_depth, total_alerts, orchestrator, …)
+     are NOT present in /health.
+
+/metrics (authenticated operational stats):
+  4. When SHAFERHUND_TOKEN is unset → 200 with full stats payload.
+  5. When SHAFERHUND_TOKEN is set and no auth header → 401.
+  6. When SHAFERHUND_TOKEN is set and correct bearer → 200 with full stats.
+  7. Wrong bearer → 401.
+  8. orchestrator block present with correct types, no nulls.
+  9. auto_deploy block present with correct types.
+  10. auto_deploy counts reflect seeded deploy_events data (24h window filter).
+  11. orchestrator counters increment after a mock run_triage_loop call.
+  12. Zero-state: fresh DB + no runs → all counts 0, avg=0.0 (no divide-by-zero).
 
 # @mock-exempt: claude_client is the Anthropic HTTP API — an external boundary.
 # run_triage_loop is tested against its real implementation; only the HTTP
@@ -64,7 +73,7 @@ def _make_client(tmp_path, token: str = ""):
 
     main_module._db = conn
     main_module._settings = settings
-    main_module._triage_queue = None  # not needed for /health
+    main_module._triage_queue = None  # not needed for /health or /metrics
     main_module._poller_healthy = False
     main_module._last_poll_at = None
 
@@ -119,12 +128,12 @@ def _make_config(max_calls: int = 5, wall_timeout: float = 10.0) -> SimpleNamesp
 
 
 # ---------------------------------------------------------------------------
-# Case 1 — Phase 1 fields still present
+# /health tests — unauthenticated liveness probe
 # ---------------------------------------------------------------------------
 
 
-def test_health_phase1_fields_present(tmp_path):
-    """GET /health → Phase 1 contract fields must all be present."""
+def test_health_returns_only_liveness_fields(tmp_path):
+    """GET /health → exactly {status, poller_healthy}, nothing else."""
     _reset_orchestrator_stats()
     client, conn = _make_client(tmp_path)
 
@@ -132,29 +141,144 @@ def test_health_phase1_fields_present(tmp_path):
     assert resp.status_code == 200
 
     data = resp.json()
-    for key in ("status", "poller_healthy", "queue_depth", "last_triage_at"):
-        assert key in data, f"Phase 1 field {key!r} missing from /health"
-
+    assert set(data.keys()) == {"status", "poller_healthy"}, (
+        f"Expected exactly {{status, poller_healthy}}, got keys: {set(data.keys())}"
+    )
     assert data["status"] == "ok"
+    assert isinstance(data["poller_healthy"], bool)
+
+    conn.close()
+
+
+def test_health_no_recon_fields(tmp_path):
+    """GET /health must NOT contain operational/recon fields."""
+    _reset_orchestrator_stats()
+    client, conn = _make_client(tmp_path)
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    recon_fields = {
+        "queue_depth", "calls_this_hour", "hourly_budget",
+        "last_poll_at", "last_triage_at",
+        "total_alerts", "total_clusters", "pending_triage",
+        "orchestrator", "auto_deploy",
+    }
+    present = recon_fields & set(data.keys())
+    assert not present, f"Recon fields must not appear in /health: {present}"
+
+    conn.close()
+
+
+def test_health_unauthenticated_no_token_set(tmp_path):
+    """GET /health returns 200 even when no token is configured."""
+    _reset_orchestrator_stats()
+    client, conn = _make_client(tmp_path, token="")
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+    conn.close()
+
+
+def test_health_unauthenticated_token_set_no_header(tmp_path):
+    """GET /health returns 200 even when token is set and no auth header is sent."""
+    _reset_orchestrator_stats()
+    client, conn = _make_client(tmp_path, token="secret123")
+
+    resp = client.get("/health")
+    assert resp.status_code == 200, (
+        f"/health must remain unauthenticated even with token set, got {resp.status_code}"
+    )
 
     conn.close()
 
 
 # ---------------------------------------------------------------------------
-# Case 2 — orchestrator block present with correct types
+# /metrics tests — authenticated operational stats
 # ---------------------------------------------------------------------------
 
 
-def test_health_orchestrator_block_present(tmp_path):
-    """GET /health → orchestrator block has 4 keys, correct types, no nulls."""
+def test_metrics_no_token_returns_200_with_full_payload(tmp_path):
+    """GET /metrics with no token configured → 200 with full operational stats."""
     _reset_orchestrator_stats()
-    client, conn = _make_client(tmp_path)
+    client, conn = _make_client(tmp_path, token="")
 
-    resp = client.get("/health")
+    resp = client.get("/metrics")
     assert resp.status_code == 200
 
     data = resp.json()
-    assert "orchestrator" in data, "'orchestrator' key missing from /health"
+    for key in (
+        "queue_depth", "calls_this_hour", "hourly_budget",
+        "last_poll_at", "last_triage_at",
+        "total_alerts", "total_clusters", "pending_triage",
+        "orchestrator", "auto_deploy",
+    ):
+        assert key in data, f"Expected field {key!r} missing from /metrics"
+
+    conn.close()
+
+
+def test_metrics_token_set_no_auth_returns_401(tmp_path):
+    """GET /metrics with token set and no auth header → 401."""
+    _reset_orchestrator_stats()
+    client, conn = _make_client(tmp_path, token="secret123")
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 401, (
+        f"Expected 401 for unauthenticated /metrics, got {resp.status_code}"
+    )
+
+    conn.close()
+
+
+def test_metrics_token_set_correct_bearer_returns_200(tmp_path):
+    """GET /metrics with correct bearer token → 200 with full stats."""
+    _reset_orchestrator_stats()
+    client, conn = _make_client(tmp_path, token="secret123")
+
+    resp = client.get("/metrics", headers={"Authorization": "Bearer secret123"})
+    assert resp.status_code == 200
+
+    data = resp.json()
+    for key in (
+        "queue_depth", "calls_this_hour", "hourly_budget",
+        "last_poll_at", "last_triage_at",
+        "total_alerts", "total_clusters", "pending_triage",
+        "orchestrator", "auto_deploy",
+    ):
+        assert key in data, f"Expected field {key!r} missing from /metrics"
+
+    conn.close()
+
+
+def test_metrics_wrong_bearer_returns_401(tmp_path):
+    """GET /metrics with wrong bearer token → 401."""
+    _reset_orchestrator_stats()
+    client, conn = _make_client(tmp_path, token="secret123")
+
+    resp = client.get("/metrics", headers={"Authorization": "Bearer wrongtoken"})
+    assert resp.status_code == 401
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# /metrics — orchestrator block correct types
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_orchestrator_block_present(tmp_path):
+    """/metrics → orchestrator block has 4 keys, correct types, no nulls."""
+    _reset_orchestrator_stats()
+    client, conn = _make_client(tmp_path)
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert "orchestrator" in data, "'orchestrator' key missing from /metrics"
 
     orch = data["orchestrator"]
     assert isinstance(orch["total_runs"], int), "total_runs must be int"
@@ -170,20 +294,20 @@ def test_health_orchestrator_block_present(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Case 3 — auto_deploy block present with correct types
+# /metrics — auto_deploy block correct types
 # ---------------------------------------------------------------------------
 
 
-def test_health_auto_deploy_block_present(tmp_path):
-    """GET /health → auto_deploy block has 4 keys, correct types."""
+def test_metrics_auto_deploy_block_present(tmp_path):
+    """/metrics → auto_deploy block has 4 keys, correct types."""
     _reset_orchestrator_stats()
     client, conn = _make_client(tmp_path)
 
-    resp = client.get("/health")
+    resp = client.get("/metrics")
     assert resp.status_code == 200
 
     data = resp.json()
-    assert "auto_deploy" in data, "'auto_deploy' key missing from /health"
+    assert "auto_deploy" in data, "'auto_deploy' key missing from /metrics"
 
     ad = data["auto_deploy"]
     assert isinstance(ad["enabled"], bool), "enabled must be bool"
@@ -195,12 +319,12 @@ def test_health_auto_deploy_block_present(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Case 4 — counts reflect data, 24h window filter works
+# /metrics — counts reflect data, 24h window filter works
 # ---------------------------------------------------------------------------
 
 
-def test_health_auto_deploy_counts_reflect_data(tmp_path):
-    """Seed deploy events and verify 24h window counts.
+def test_metrics_auto_deploy_counts_reflect_data(tmp_path):
+    """Seed deploy events and verify 24h window counts via /metrics.
 
     Seeding:
       - 1 auto-deploy outside 24h window (should NOT appear in deployed_last_24h)
@@ -251,7 +375,7 @@ def test_health_auto_deploy_counts_reflect_data(tmp_path):
             (0, "auto-deploy", "ok", "orchestrator", recent_ts, recent_ts),
         )
 
-    resp = client.get("/health")
+    resp = client.get("/metrics")
     assert resp.status_code == 200
 
     ad = resp.json()["auto_deploy"]
@@ -264,11 +388,11 @@ def test_health_auto_deploy_counts_reflect_data(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Case 5 — orchestrator counters increment after a mock loop run
+# /metrics — orchestrator counters increment after a mock loop run
 # ---------------------------------------------------------------------------
 
 
-def test_health_orchestrator_counters_increment(tmp_path):
+def test_metrics_orchestrator_counters_increment(tmp_path):
     """run_triage_loop with 2 tool calls + finalize → total_runs=1, avg reflects 2 calls."""
     _reset_orchestrator_stats()
 
@@ -318,16 +442,16 @@ def test_health_orchestrator_counters_increment(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Case 6 — zero state: fresh counters, no divide-by-zero
+# /metrics — zero state: fresh counters, no divide-by-zero
 # ---------------------------------------------------------------------------
 
 
-def test_health_zero_state_no_divide_by_zero(tmp_path):
+def test_metrics_zero_state_no_divide_by_zero(tmp_path):
     """Fresh DB + no runs → all counts 0, avg_tool_calls_per_run == 0.0."""
     _reset_orchestrator_stats()
     client, conn = _make_client(tmp_path)
 
-    resp = client.get("/health")
+    resp = client.get("/metrics")
     assert resp.status_code == 200
 
     data = resp.json()


### PR DESCRIPTION
## Summary
- `/health` used to leak queue depth, tailer timestamps, alert/cluster counts, orchestrator stats, and auto-deploy counters to any unauthenticated caller — useful reconnaissance if the dashboard is reachable.
- Trim `/health` to `{status, poller_healthy}` — exactly what a container probe needs, nothing more.
- Add `/metrics` behind the existing bearer-token auth, carrying the full stats payload.
- Replace 6 old `/health` tests with 12 new tests spanning both endpoints and the full auth matrix (no-token / token + no-auth / token + correct / token + wrong).
- `@decision DEC-HEALTH-002` documents the split and its rationale.

## Test plan
- [x] `pytest tests/` — 94 passed, 0 failures
- [x] Live HTTP with no token: `/health` → `{status, poller_healthy}` only, `/metrics` → 200 with full stats
- [x] Live HTTP with `SHAFERHUND_TOKEN=testsecret`: `/metrics` no-auth → 401, wrong bearer → 401, correct bearer → 200, `/health` → 200 (unauthenticated)
- [x] Templates contain no references to `/health` or `/metrics`
- [x] No Wazuh or Suricata compose healthcheck references `/health` — they curl their own containers

## Notes
- 5 of 5 findings from a `/cso` security audit. F1 → #18, F2 → #19, F3 → #20. F4 (LLM prompt injection + ai_confidence fix) is still pending as a separate PR.
- **Do not auto-merge.** Leaving open for review.
- Minor behaviour change: container/probe tools that parsed richer `/health` JSON need to move to `/metrics` and supply the bearer token. The shaferhund stack's own compose healthcheck doesn't touch `/health`, so internal rollout is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)