### PR TITLE
chore(gitignore): ignore runtime and session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,12 @@ wazuh/
 
 # Wazuh Docker (vendored, modify compose from here)
 # wazuh-docker/ is tracked
+
+# Session / tester artifacts — see CLAUDE.md "No /tmp/" convention
+tmp/
+
+# Auto-generated decision registry (produced by surface.sh)
+DECISIONS.md
+
+# External reference repos accidentally cloned into the tree
+awesome-cybersecurity-blueteam/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ wazuh/
 # Session / tester artifacts — see CLAUDE.md "No /tmp/" convention
 tmp/
 
+# Feature-branch worktrees — per Sacred Practice #2 "Main is Sacred"
+.worktrees/
+
 # Auto-generated decision registry (produced by surface.sh)
 DECISIONS.md
 


### PR DESCRIPTION
## Summary
Three runtime/session artifacts were showing up as untracked in every `git status`:
- `tmp/` — session scratch (per CLAUDE.md's "No /tmp/" convention)
- `DECISIONS.md` — auto-generated from `@decision` annotations by `surface.sh`
- `awesome-cybersecurity-blueteam/` — external reference git repo accidentally cloned here

None should be tracked. Adding them to `.gitignore` keeps the working tree clean.

## Test plan
- [x] `pytest tests/` — 112 passed, 0 failures
- [x] `git status` on an unchanged working tree shows zero untracked items after the gitignore lands
- [x] `git ls-files | grep -E '^(tmp/|DECISIONS\.md$|awesome-cybersecurity-blueteam/)'` — empty (nothing was previously tracked)

## Notes
- Follow-up to the just-landed CSO audit sequence (#18, #19, #20, #21, #22).
- Safe to fast-merge — single-file chore, zero blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)