### PR TITLE
feat(#25): sigma-cli startup probe + /metrics exposure

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -15,6 +15,7 @@ fail fast rather than silently degrading.
 """
 
 import json
+from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import field_validator
@@ -54,6 +55,13 @@ class Settings(BaseSettings):
     # Orchestrator caps (Phase 2)
     orch_max_tool_calls: int = 5
     orch_wall_timeout_seconds: float = 10.0
+
+    # Sigma-cli availability — populated by the lifespan startup probe
+    # (REQ-P0-P25-003). Defaults to False so a misconfigured container can
+    # never accidentally auto-deploy Sigma rules before the probe confirms
+    # sigma-cli is usable. Set by _probe_sigmac() in main.py lifespan.
+    sigmac_available: bool = False
+    sigmac_version: Optional[str] = None
 
     # Auto-deploy policy gate (Phase 2, REQ-P0-P2-006, DEC-AUTODEPLOY-001)
     # Default OFF — operator must explicitly enable via env var.

--- a/agent/main.py
+++ b/agent/main.py
@@ -57,6 +57,7 @@ import asyncio
 import json
 import logging
 import os
+import subprocess
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -111,6 +112,55 @@ _last_poll_at: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
+# Sigma-cli startup probe
+# ---------------------------------------------------------------------------
+
+def _probe_sigmac(settings: Settings) -> None:
+    """Probe for sigma-cli at startup and mutate settings fields in place.
+
+    Runs ``sigma --version`` once. On success, sets sigmac_available=True
+    and sigmac_version to the version string. On any failure
+    (FileNotFoundError, non-zero exit, or TimeoutExpired), leaves
+    sigmac_available=False and logs a single WARNING. Does NOT raise —
+    graceful degradation is the point.
+
+    @decision DEC-SIGMA-DEGRADE-001
+    @title Startup probe flips settings.sigmac_available once; downstream reads the bool
+    @status accepted
+    @rationale One sigma-cli invocation per startup is enough. Downstream code
+               (policy gate, orchestrator) reads sigmac_available without re-probing.
+               Re-probing on every triage would add 50-100 ms of latency per rule
+               for no benefit. Defaults to False so a misconfigured container can
+               never accidentally auto-deploy Sigma rules before the probe confirms
+               sigma-cli is usable (fail-safe default).
+    """
+    try:
+        result = subprocess.run(
+            ["sigma", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            settings.sigmac_available = True
+            settings.sigmac_version = result.stdout.strip()
+            log.info("sigma-cli available: %s", settings.sigmac_version)
+            return
+        # Non-zero exit — treat as unavailable
+        log.warning(
+            "sigma-cli not available; Sigma rules will generate but not auto-deploy"
+        )
+    except FileNotFoundError:
+        log.warning(
+            "sigma-cli not available; Sigma rules will generate but not auto-deploy"
+        )
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "sigma-cli not available; Sigma rules will generate but not auto-deploy"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Lifespan
 # ---------------------------------------------------------------------------
 
@@ -119,6 +169,7 @@ async def lifespan(app: FastAPI):
     global _settings, _db, _triage_queue, _clusterer, _tailer_task, _suricata_tailer_task
 
     _settings = get_settings()
+    _probe_sigmac(_settings)
     _db = init_db(_settings.db_path)
     _clusterer = AlertClusterer(
         window_seconds=_settings.cluster_window_seconds,
@@ -288,6 +339,12 @@ async def metrics() -> JSONResponse:
             "deployed_last_24h": deployed_24h,
             "skipped_last_24h": skipped_24h,
             "reverted_last_24h": reverted_24h,
+        },
+        # Sigma-cli availability — set once at startup by _probe_sigmac()
+        # (REQ-P0-P25-003, REQ-P1-P25-001). Not exposed via /health (CSO F5).
+        "sigmac": {
+            "available": getattr(_settings, "sigmac_available", False) if _settings else False,
+            "version": getattr(_settings, "sigmac_version", None) if _settings else None,
         },
     })
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -60,6 +60,9 @@ def _make_settings(rules_dir: str, token: str = "") -> SimpleNamespace:
         suricata_eve_file="/dev/null",
         triage_hourly_budget=20,
         AUTO_DEPLOY_ENABLED=False,
+        # Sigma-cli probe fields (REQ-P0-P25-003) — default False (not probed in tests)
+        sigmac_available=False,
+        sigmac_version=None,
     )
 
 

--- a/tests/test_sigmac_probe.py
+++ b/tests/test_sigmac_probe.py
@@ -1,0 +1,174 @@
+"""
+Tests for the sigma-cli startup probe (REQ-P0-P25-003).
+
+Verifies:
+  1. Successful sigma --version → sigmac_available=True, sigmac_version set.
+  2. FileNotFoundError (sigma not on PATH) → sigmac_available=False, WARNING logged.
+  3. Non-zero exit code → sigmac_available=False, WARNING logged.
+  4. TimeoutExpired → sigmac_available=False, WARNING logged.
+  5. /metrics endpoint exposes sigmac.available and sigmac.version fields.
+
+@decision DEC-SIGMA-DEGRADE-001
+@title Startup probe flips settings.sigmac_available once; downstream reads the bool
+@status accepted
+@rationale Tests confirm fail-safe default (False) and that all failure modes
+           produce one WARNING rather than raising. The probe runs once per
+           startup; re-probing on every triage would add 50-100ms latency per rule.
+           Mocking subprocess.run is acceptable here — it IS the external boundary
+           (a subprocess exec to sigma-cli, an external binary).
+
+# @mock-exempt: subprocess.run is an external process boundary — spawning the
+# sigma-cli binary. We cannot install sigma-cli in CI, so mocking the OS-level
+# call is the only viable strategy. This is exactly the pattern the Sacred
+# Practice exemption covers (external boundary = HTTP APIs, third-party
+# services, OS process exec).
+"""
+
+import logging
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import agent.main as main_module
+from agent.config import Settings
+from agent.main import _probe_sigmac
+from agent.models import init_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_settings() -> SimpleNamespace:
+    """Minimal settings namespace with sigmac fields at their defaults."""
+    return SimpleNamespace(
+        sigmac_available=False,
+        sigmac_version=None,
+        shaferhund_token="",
+        rules_dir="/tmp/rules-probe-test",
+        db_path=":memory:",
+        alerts_file="/dev/null",
+        suricata_eve_file="/dev/null",
+        triage_hourly_budget=20,
+        AUTO_DEPLOY_ENABLED=False,
+    )
+
+
+def _make_completed_process(returncode: int, stdout: str) -> MagicMock:
+    cp = MagicMock()
+    cp.returncode = returncode
+    cp.stdout = stdout
+    return cp
+
+
+def _make_metrics_client(tmp_path):
+    """Return a TestClient with module singletons patched for /metrics tests."""
+    conn = init_db(":memory:")
+    settings = _fresh_settings()
+
+    main_module._db = conn
+    main_module._settings = settings
+    main_module._triage_queue = None
+    main_module._poller_healthy = False
+    main_module._last_poll_at = None
+
+    client = TestClient(main_module.app, raise_server_exceptions=True)
+    return client, conn
+
+
+# ---------------------------------------------------------------------------
+# Probe unit tests
+# ---------------------------------------------------------------------------
+
+def test_probe_sets_available_true_on_success():
+    """Successful sigma --version → sigmac_available=True, sigmac_version populated."""
+    settings = _fresh_settings()
+    mock_result = _make_completed_process(0, "sigma-cli, version 1.0.4\n")
+
+    with patch("agent.main.subprocess.run", return_value=mock_result) as mock_run:
+        _probe_sigmac(settings)
+
+    mock_run.assert_called_once_with(
+        ["sigma", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert settings.sigmac_available is True
+    assert settings.sigmac_version == "sigma-cli, version 1.0.4"
+
+
+def test_probe_sets_available_false_on_filenotfound(caplog):
+    """FileNotFoundError (sigma not on PATH) → sigmac_available=False, one WARNING."""
+    settings = _fresh_settings()
+
+    with caplog.at_level(logging.WARNING, logger="agent.main"):
+        with patch("agent.main.subprocess.run", side_effect=FileNotFoundError()):
+            _probe_sigmac(settings)
+
+    assert settings.sigmac_available is False
+    assert settings.sigmac_version is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "sigma-cli not available" in warnings[0].message
+
+
+def test_probe_sets_available_false_on_nonzero_exit(caplog):
+    """Non-zero exit from sigma --version → sigmac_available=False, one WARNING."""
+    settings = _fresh_settings()
+    mock_result = _make_completed_process(1, "")
+
+    with caplog.at_level(logging.WARNING, logger="agent.main"):
+        with patch("agent.main.subprocess.run", return_value=mock_result):
+            _probe_sigmac(settings)
+
+    assert settings.sigmac_available is False
+    assert settings.sigmac_version is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "sigma-cli not available" in warnings[0].message
+
+
+def test_probe_sets_available_false_on_timeout(caplog):
+    """TimeoutExpired → sigmac_available=False, one WARNING."""
+    settings = _fresh_settings()
+
+    with caplog.at_level(logging.WARNING, logger="agent.main"):
+        with patch(
+            "agent.main.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["sigma", "--version"], timeout=5),
+        ):
+            _probe_sigmac(settings)
+
+    assert settings.sigmac_available is False
+    assert settings.sigmac_version is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "sigma-cli not available" in warnings[0].message
+
+
+# ---------------------------------------------------------------------------
+# /metrics endpoint — sigmac block
+# ---------------------------------------------------------------------------
+
+def test_metrics_endpoint_exposes_sigmac_fields(tmp_path):
+    """/metrics response contains sigmac.available and sigmac.version."""
+    client, conn = _make_metrics_client(tmp_path)
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert "sigmac" in data, "'sigmac' key missing from /metrics response"
+
+    sigmac = data["sigmac"]
+    assert "available" in sigmac, "'sigmac.available' missing"
+    assert "version" in sigmac, "'sigmac.version' missing"
+    # Default state: sigma-cli was not probed in this test (settings patched directly)
+    assert sigmac["available"] is False
+    assert sigmac["version"] is None
+
+    conn.close()


### PR DESCRIPTION
Closes #25 (REQ-P0-P25-003, plus REQ-P1-P25-001 bundled in since the /metrics seam was already open).

## Summary
Wave A of Phase 2.5. Adds graceful-degradation detection: the app probes `sigma --version` once at startup. If missing, logs one WARNING and flips `settings.sigmac_available=False`. If present, logs one INFO and records the version. Either way, the app starts cleanly — no crashes on a missing sigma-cli.

- `_probe_sigmac(settings)` helper wraps the subprocess call, handles all three failure modes (FileNotFoundError, non-zero exit, TimeoutExpired) identically
- `/metrics` (authenticated, post-CSO F5) now exposes `sigmac: {available, version}`
- `/health` stays minimal — `{status, poller_healthy}` only, CSO F5 invariant preserved
- `@decision DEC-SIGMA-DEGRADE-001` annotation explains the one-probe-per-startup rationale

## Test plan
- [x] `pytest tests/` — 117 passed, 0 regressions
- [x] Live uvicorn without sigma-cli on PATH: `/metrics.sigmac = {available: false, version: null}`, `/health = {status, poller_healthy}`, WARNING emits exactly once at startup (not per-request)
- [ ] Manual: with sigma-cli installed, restart and verify `/metrics.sigmac.version` returns a real version string

## Notes
- Wave A parallel sibling: #24 (sigmac wrapper + Dockerfile install). Both ship from main; neither blocks the other.
- Wave B (#26) depends on both #24 and #25 landing first. The contract between them is the `settings.sigmac_available` bool — #26's policy gate reads it via attribute access (no subprocess calls in the gate per its pure-function contract).
- **Do not auto-merge.** Leave open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)