### PR TITLE
feat(#24): agent/sigmac.py subprocess wrapper + sigma-cli install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install the sigma-cli Wazuh backend plugin.
+# pysigma-backend-wazuh is not published on PyPI; the official mechanism
+# is sigma-cli's plugin system.  The `sigma` binary comes from sigma-cli
+# (already in requirements.txt); this step installs the Wazuh conversion
+# backend into sigma-cli's plugin registry so `sigma convert -t wazuh`
+# works.  If the plugin registry is unavailable at build time the image
+# still builds — the startup probe (REQ-P0-P25-003) will detect the
+# missing backend and set sigmac_available=False at runtime.
+RUN sigma plugin install wazuh || true
+
 COPY agent/ ./agent/
 
 # Create directories for volumes

--- a/agent/sigmac.py
+++ b/agent/sigmac.py
@@ -1,0 +1,124 @@
+"""
+Subprocess wrapper around the sigma-cli ``sigma convert`` command.
+
+Converts Sigma YAML rules to Wazuh XML by invoking sigma-cli as an
+external process.  This module contains no import-time side effects —
+it is safe to import even when sigma-cli is not installed; failures
+surface only at call time via SigmaConversionError.
+
+@decision DEC-SIGMA-CONVERT-001
+@title Subprocess wrapper over sigma-cli, not the pySigma Python API
+@status accepted
+@rationale sigma-cli's Wazuh backend is distributed as a separate plugin
+           (``sigma plugin install wazuh``). The subprocess boundary isolates
+           the main process from any exception the backend raises or crashes,
+           keeps the pySigma import surface out of our dependency graph, and
+           makes it trivial to swap sigma-cli versions without touching
+           application code.  The trade-off is an extra process-spawn per
+           conversion (~50–200 ms), which is acceptable for an async, low-
+           throughput auto-deploy path.
+
+@decision DEC-SIGMA-DEGRADE-001
+@title Graceful degradation when sigma-cli is absent
+@status accepted
+@rationale If the ``sigma`` executable is not on PATH, ``convert()`` raises
+           SigmaConversionError with a clear message instead of crashing the
+           process.  The startup probe (REQ-P0-P25-003, agent/main.py) calls
+           ``sigma --version`` at boot; on failure it sets
+           ``settings.sigmac_available = False``, which prevents the policy
+           gate from ever routing a Sigma rule into this function.  The two
+           layers together mean sigma-cli is strictly optional at runtime.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+class SigmaConversionError(Exception):
+    """Raised when sigma-cli conversion fails for any reason.
+
+    Callers should catch this exception and record a skipped
+    ``deploy_events`` row (DEC-AUTODEPLOY-003) rather than propagating
+    it upward — a failed conversion must not abort an otherwise healthy
+    triage cycle.
+    """
+
+
+def convert(yaml_content: str, rule_id: str, rules_dir: Path) -> Path:
+    """Convert a Sigma YAML rule to Wazuh XML and write it to disk.
+
+    Invokes ``sigma convert -t wazuh`` as a subprocess, feeds the YAML
+    via stdin, writes the resulting XML to
+    ``<rules_dir>/sigma_<rule_id>.xml``, and returns the output path.
+
+    Args:
+        yaml_content: The raw Sigma rule YAML as a string.
+        rule_id:      An identifier used to name the output file.
+                      Only alphanumerics, hyphens, and underscores are
+                      safe; callers are responsible for sanitisation.
+        rules_dir:    Directory where the XML file will be written.
+                      Must exist before calling this function.
+
+    Returns:
+        Path to the written XML file (``rules_dir / f"sigma_{rule_id}.xml"``).
+
+    Raises:
+        SigmaConversionError: On any of the following conditions —
+            * the ``sigma`` executable is not found on PATH
+            * sigma-cli exits with a non-zero return code
+            * sigma-cli produces empty stdout (no rules converted)
+            * the stdout is not well-formed XML
+    """
+    cmd = ["sigma", "convert", "-t", "wazuh"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            input=yaml_content,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        raise SigmaConversionError(
+            "sigma executable not found on PATH. "
+            "Install sigma-cli and the Wazuh backend plugin "
+            "('pip install sigma-cli && sigma plugin install wazuh') "
+            "or set SIGMAC_PATH to its full path."
+        ) from None
+    except subprocess.TimeoutExpired:
+        raise SigmaConversionError(
+            f"sigma convert timed out after 30 s for rule_id={rule_id!r}"
+        ) from None
+
+    if result.returncode != 0:
+        stderr_snippet = (result.stderr or "").strip()[:500]
+        raise SigmaConversionError(
+            f"sigma convert exited with code {result.returncode} "
+            f"for rule_id={rule_id!r}. stderr: {stderr_snippet}"
+        )
+
+    xml_output = result.stdout.strip()
+
+    if not xml_output:
+        raise SigmaConversionError(
+            f"sigma convert produced empty output for rule_id={rule_id!r}. "
+            "The rule may not match any Wazuh-compatible log fields, or the "
+            "Wazuh backend plugin may not be installed "
+            "('sigma plugin install wazuh')."
+        )
+
+    # Validate well-formedness before writing to disk.
+    try:
+        ET.fromstring(xml_output)
+    except ET.ParseError as exc:
+        raise SigmaConversionError(
+            f"sigma convert output for rule_id={rule_id!r} is not valid XML: {exc}"
+        ) from exc
+
+    out_path = rules_dir / f"sigma_{rule_id}.xml"
+    out_path.write_text(xml_output, encoding="utf-8")
+    return out_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,11 @@ jinja2==3.1.6
 aiofiles==24.1.0
 yara-python==4.5.0
 pysigma>=1.2.0
+# sigma-cli: CLI wrapper for pySigma rule conversion.
+# pysigma-backend-wazuh does not exist on PyPI; the Wazuh backend is
+# installed at container build time via `sigma plugin install wazuh`
+# (see Dockerfile).  sigma-cli==1.0.4 is the last stable 1.x release.
+sigma-cli==1.0.4
 pytest==9.0.3
 pytest-asyncio==1.3.0
 httpx==0.28.1

--- a/tests/test_sigmac.py
+++ b/tests/test_sigmac.py
@@ -1,0 +1,230 @@
+"""
+Tests for agent/sigmac.py — the sigma-cli subprocess wrapper.
+
+All tests except the happy-path real-invocation variant use mocks for
+subprocess.run so sigma-cli does not need to be installed in CI.
+
+# @mock-exempt: subprocess.run is an external process boundary (sigma-cli
+# is a third-party CLI tool).  Mocking it here is consistent with Sacred
+# Practice #5 — we are NOT mocking internal modules.  The real-invocation
+# test (test_convert_real_invocation_happy_path) exercises the full stack
+# when sigma-cli is present.
+
+@decision DEC-SIGMA-CONVERT-001
+@title Tests validate the subprocess contract, not sigma-cli internals
+@status accepted
+@rationale The wrapper's correctness is about what it does with sigma-cli's
+           output (non-zero exit → raise, empty stdout → raise, invalid XML
+           → raise, good XML → write file).  Mocking subprocess.run is the
+           right boundary here: it is an external process, not an internal
+           module.  The single real-invocation test is skipif-guarded so CI
+           without sigma-cli still gets full mock coverage.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.sigmac import SigmaConversionError, convert
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_SIGMA_YAML = """\
+title: Test Suspicious Process
+id: 11111111-1111-1111-1111-111111111111
+status: test
+description: Minimal sigma rule for unit testing
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'suspicious.exe'
+    condition: selection
+level: high
+"""
+
+MINIMAL_WAZUH_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<group name="sigma,windows,">
+  <rule id="100001" level="12">
+    <field name="CommandLine" type="pcre2">(?i)suspicious\\.exe</field>
+    <description>Test Suspicious Process</description>
+    <options>no_full_log</options>
+  </rule>
+</group>
+"""
+
+
+def _make_completed_process(returncode=0, stdout="", stderr=""):
+    """Build a CompletedProcess-like mock."""
+    mock = MagicMock(spec=subprocess.CompletedProcess)
+    mock.returncode = returncode
+    mock.stdout = stdout
+    mock.stderr = stderr
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Happy path — mocked subprocess returning valid XML
+# ---------------------------------------------------------------------------
+
+
+def test_convert_happy_path_produces_valid_xml(tmp_path):
+    """convert() writes a valid XML file and returns its path."""
+    with patch("agent.sigmac.subprocess.run") as mock_run:
+        mock_run.return_value = _make_completed_process(
+            returncode=0, stdout=MINIMAL_WAZUH_XML
+        )
+
+        out_path = convert(
+            yaml_content=MINIMAL_SIGMA_YAML,
+            rule_id="test-rule-001",
+            rules_dir=tmp_path,
+        )
+
+    assert out_path == tmp_path / "sigma_test-rule-001.xml"
+    assert out_path.exists()
+    content = out_path.read_text(encoding="utf-8")
+    # Must start with the XML declaration or a root tag.
+    assert content.strip().startswith("<?xml") or content.strip().startswith("<")
+    # Must be parseable by the stdlib XML parser (basic well-formedness).
+    import xml.etree.ElementTree as ET
+    tree = ET.parse(str(out_path))
+    assert tree.getroot() is not None
+
+    # Verify subprocess was called with correct arguments.
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args
+    cmd = call_args.args[0]
+    assert cmd[:4] == ["sigma", "convert", "-t", "wazuh"]
+    assert call_args.kwargs.get("input") == MINIMAL_SIGMA_YAML
+    assert call_args.kwargs.get("capture_output") is True
+    assert call_args.kwargs.get("text") is True
+    assert call_args.kwargs.get("timeout") == 30
+
+
+# ---------------------------------------------------------------------------
+# Error paths (all mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_convert_raises_on_nonzero_exit(tmp_path):
+    """Non-zero sigma-cli exit code raises SigmaConversionError with stderr."""
+    stderr_text = "Error: unsupported target platform"
+    with patch("agent.sigmac.subprocess.run") as mock_run:
+        mock_run.return_value = _make_completed_process(
+            returncode=1, stdout="", stderr=stderr_text
+        )
+        with pytest.raises(SigmaConversionError) as exc_info:
+            convert(MINIMAL_SIGMA_YAML, "bad-rule", tmp_path)
+
+    assert "code 1" in str(exc_info.value)
+    assert stderr_text in str(exc_info.value)
+
+
+def test_convert_raises_on_empty_output(tmp_path):
+    """Exit 0 with empty stdout raises SigmaConversionError."""
+    with patch("agent.sigmac.subprocess.run") as mock_run:
+        mock_run.return_value = _make_completed_process(
+            returncode=0, stdout="", stderr=""
+        )
+        with pytest.raises(SigmaConversionError) as exc_info:
+            convert(MINIMAL_SIGMA_YAML, "empty-rule", tmp_path)
+
+    assert "empty output" in str(exc_info.value)
+
+
+def test_convert_raises_when_sigma_executable_missing(tmp_path):
+    """FileNotFoundError from subprocess.run becomes SigmaConversionError."""
+    with patch("agent.sigmac.subprocess.run", side_effect=FileNotFoundError()):
+        with pytest.raises(SigmaConversionError) as exc_info:
+            convert(MINIMAL_SIGMA_YAML, "no-sigma", tmp_path)
+
+    assert "sigma executable not found" in str(exc_info.value)
+
+
+def test_convert_raises_on_invalid_xml(tmp_path):
+    """sigma-cli returning malformed XML raises SigmaConversionError."""
+    not_xml = "this is definitely not xml <broken"
+    with patch("agent.sigmac.subprocess.run") as mock_run:
+        mock_run.return_value = _make_completed_process(
+            returncode=0, stdout=not_xml, stderr=""
+        )
+        with pytest.raises(SigmaConversionError) as exc_info:
+            convert(MINIMAL_SIGMA_YAML, "bad-xml", tmp_path)
+
+    assert "not valid XML" in str(exc_info.value)
+
+
+def test_convert_raises_on_invalid_yaml():
+    """Malformed YAML input: sigma-cli exits non-zero, wrapper raises SigmaConversionError.
+
+    The wrapper itself does not parse YAML — it passes content to sigma-cli
+    verbatim.  This test simulates sigma-cli's response to malformed input
+    (non-zero exit with an error on stderr).
+    """
+    malformed_yaml = "title: [unclosed bracket\ndetection:\n  - bad: yaml: here:"
+    stderr_text = "Error parsing sigma rule: invalid YAML"
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        rules_dir = Path(tmp_dir)
+        with patch("agent.sigmac.subprocess.run") as mock_run:
+            mock_run.return_value = _make_completed_process(
+                returncode=1, stdout="", stderr=stderr_text
+            )
+            with pytest.raises(SigmaConversionError) as exc_info:
+                convert(malformed_yaml, "malformed-rule", rules_dir)
+
+    assert "code 1" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Optional: real sigma-cli invocation (skipped if sigma not on PATH)
+# ---------------------------------------------------------------------------
+
+
+def _sigma_on_path() -> bool:
+    """Return True if sigma-cli is available."""
+    try:
+        subprocess.run(
+            ["sigma", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+@pytest.mark.skipif(
+    not _sigma_on_path(),
+    reason="sigma-cli not installed in this environment",
+)
+def test_convert_real_invocation_happy_path(tmp_path):
+    """Real sigma-cli invocation: verifies the subprocess contract end-to-end.
+
+    This test is skipped in environments without sigma-cli.  When sigma-cli
+    and the Wazuh backend are installed, it validates the full stack.
+    """
+    out_path = convert(
+        yaml_content=MINIMAL_SIGMA_YAML,
+        rule_id="real-test-rule",
+        rules_dir=tmp_path,
+    )
+    assert out_path.exists()
+    content = out_path.read_text(encoding="utf-8")
+    assert content.strip()  # non-empty
+
+    import xml.etree.ElementTree as ET
+    tree = ET.parse(str(out_path))
+    assert tree.getroot() is not None


### PR DESCRIPTION
Closes #24 (REQ-P0-P25-001).

## Summary
Wave A of Phase 2.5 (Sigma deploy path). Ships the sigmac subprocess wrapper and the container-side sigma-cli install. Pure function; no policy wiring yet — that's Wave B (#26).

- **New:** `agent/sigmac.py` — `convert(yaml_content, rule_id, rules_dir)` invokes `sigma convert -t wazuh` via subprocess (capture_output, text, timeout=30, stdin-fed). Raises `SigmaConversionError` on any failure mode.
- **New:** `tests/test_sigmac.py` — 6 contract tests + 1 real-invocation test guarded by `skipif(sigma not on PATH)`.
- **Deps:** `sigma-cli==1.0.4` added to `requirements.txt`.
- **Container:** Dockerfile runs `sigma plugin install wazuh || true` after pip install.

## Material spec deviation
The planner's issue #24 listed `pysigma-backend-wazuh` as a pip package, but it does NOT exist on PyPI. Upstream sigma-cli ships the Wazuh backend as a plugin installed via `sigma plugin install wazuh`, not a separate pip package. Used that mechanism. The `|| true` lets the image build proceed if the plugin registry is unreachable; the startup probe (from companion PR for #25) sets `settings.sigmac_available=False` at runtime so the policy gate never calls `convert()` when the plugin is missing.

## Test plan
- [x] `pytest tests/` — 118 passed, 1 skipped (real sigma), 0 regressions
- [x] `agent/sigmac.py` import clean
- [x] `grep sigma-cli requirements.txt` → `sigma-cli==1.0.4`
- [x] Dockerfile pip install order: `requirements.txt` before `sigma plugin install wazuh`
- [ ] Manual: build the container image and verify `sigma --version` works inside

## Notes
- Wave A parallel sibling: #25 (startup probe + `/metrics`). Both ship from main; neither blocks the other.
- Wave B (#26) depends on both #24 and #25 landing first.
- **Do not auto-merge.** Leave open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)