### PR TITLE
feat(#26): Sigma auto-deploy via sigmac conversion

### DIFF
--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -104,7 +104,9 @@ from .models import (
     record_deploy_event,
     update_cluster_ai,
 )
+from . import sigmac as _sigmac
 from .policy import should_auto_deploy
+from .sigmac import SigmaConversionError
 from .triage import TriageResult
 
 log = logging.getLogger(__name__)
@@ -1210,8 +1212,43 @@ def _run_auto_deploy(
             if deploy_ok:
                 # Write rule file — mkdir is a no-op when dir already exists.
                 rules_dir.mkdir(parents=True, exist_ok=True)
-                rule_path = rules_dir / f"{rule_id}.yar"
-                rule_path.write_text(rule_row["rule_content"] or "", encoding="utf-8")
+
+                rule_type = rule_row["rule_type"]
+
+                if rule_type == "sigma":
+                    # See DEC-AUTODEPLOY-003 in agent/policy.py.
+                    #
+                    # Sigma conversion can fail (malformed rule, plugin missing, subprocess error).
+                    # Record a 'skipped' deploy_events row BEFORE the exception propagates so the
+                    # failure is auditable — the outer try/except below would otherwise swallow
+                    # the failure without a trail.
+                    try:
+                        rule_path = _sigmac.convert(
+                            rule_row["rule_content"] or "",
+                            rule_id,
+                            rules_dir,
+                        )
+                    except SigmaConversionError as exc:
+                        log.warning(
+                            "Sigma conversion failed for rule %s in cluster %s: %s",
+                            rule_id,
+                            cluster_id,
+                            exc,
+                        )
+                        record_deploy_event(
+                            conn,
+                            rule_id=rule_id,
+                            action="skipped",
+                            reason=f"sigmac conversion failed: {exc}",
+                            actor="orchestrator",
+                            rule_type=rule_type,
+                            src_ip=cluster_row["src_ip"],
+                        )
+                        continue
+                else:
+                    # YARA: file-drop to RULES_DIR/<rule_id>.yar (unchanged)
+                    rule_path = rules_dir / f"{rule_id}.yar"
+                    rule_path.write_text(rule_row["rule_content"] or "", encoding="utf-8")
 
                 mark_rule_deployed(conn, rule_id)
                 record_deploy_event(
@@ -1220,7 +1257,7 @@ def _run_auto_deploy(
                     action="auto-deploy",
                     reason=reason,
                     actor="orchestrator",
-                    rule_type=rule_row["rule_type"],
+                    rule_type=rule_type,
                     src_ip=cluster_row["src_ip"],
                 )
                 log.info(

--- a/agent/policy.py
+++ b/agent/policy.py
@@ -15,12 +15,21 @@ Callers are responsible for supplying recent_deploys as a list.
                never silently auto-deploys on first run.
            (2) Every check is a hard gate with a named failure reason so the audit
                log tells operators exactly why a rule was or was not deployed.
-           Sigma rules are excluded in Phase 2 because there is no deploy path
-           without a sigmac conversion step (deferred to Phase 3). Only YARA
-           rules have a well-defined file-drop deploy path today.
+           Sigma deploy is unblocked in Phase 2.5 via sigmac conversion —
+           see DEC-AUTODEPLOY-003.
            The dedup window prevents duplicate rules from being deployed when
            the same threat pattern triggers multiple overlapping clusters within
            a short window — the first deploy wins and subsequent ones are skipped.
+
+@decision DEC-AUTODEPLOY-003
+@title Sigma now auto-deploys when sigmac_available=True
+@status accepted
+@rationale The rule_type gate accepts {'yara', 'sigma'}; the additional
+           sigmac_available gate for Sigma prevents deploy attempts when the
+           runtime probe found sigma-cli missing (settings.sigmac_available=False).
+           Keeps the function pure — sigmac_available is an attribute read,
+           never a subprocess call. DEC-AUTODEPLOY-002's ai_confidence None-guard
+           still protects both rule types equally.
 """
 
 import time
@@ -31,6 +40,11 @@ from typing import Any
 _RuleLike = Any
 _ClusterLike = Any
 _SettingsLike = Any
+
+# Rule types eligible for auto-deploy.  Only these two have defined deploy paths:
+#   yara  — file-drop to RULES_DIR/<rule_id>.yar
+#   sigma — sigmac conversion to RULES_DIR/sigma_<rule_id>.xml (requires sigmac_available=True)
+_ELIGIBLE_RULE_TYPES = frozenset({"yara", "sigma"})
 
 
 def should_auto_deploy(
@@ -59,6 +73,7 @@ def should_auto_deploy(
                     AUTO_DEPLOY_CONF_THRESHOLD (float)
                     AUTO_DEPLOY_DEDUP_WINDOW_SECONDS (int)
                     AUTO_DEPLOY_SEVERITIES (list[str])
+                    sigmac_available (bool, optional — checked only for sigma rules)
 
     Returns:
         (True, 'ok') when all checks pass.
@@ -69,9 +84,18 @@ def should_auto_deploy(
     if not settings.AUTO_DEPLOY_ENABLED:
         return False, "auto-deploy disabled"
 
-    # Check 2: only YARA rules have a deploy path in Phase 2
-    if rule.rule_type != "yara":
+    # Check 2: rule_type must be in the eligible set {'yara', 'sigma'}
+    # See DEC-AUTODEPLOY-003 for why sigma is now eligible.
+    if rule.rule_type not in _ELIGIBLE_RULE_TYPES:
         return False, "rule_type not eligible for auto-deploy"
+
+    # Check 2a: Sigma additionally requires sigmac to be available at runtime.
+    # sigmac_available is set by the startup probe (agent/main.py lifespan).
+    # This gate is a pure attribute read — no subprocess, no I/O.
+    # See DEC-AUTODEPLOY-003.
+    if rule.rule_type == "sigma":
+        if not getattr(settings, "sigmac_available", False):
+            return False, "sigmac not available"
 
     # Check 3: syntax must be valid
     if rule.syntax_valid is not True:
@@ -89,7 +113,8 @@ def should_auto_deploy(
     #            between instances of 'NoneType' and 'float' here. Now
     #            finalize_triage always writes a float (default 0.0) and the
     #            gate returns a clean (False, reason) on missing confidence
-    #            rather than raising.
+    #            rather than raising. DEC-AUTODEPLOY-002 applies to both YARA
+    #            and Sigma rules equally.
     if cluster.ai_confidence is None:
         return False, "confidence not set"
     if cluster.ai_confidence < settings.AUTO_DEPLOY_CONF_THRESHOLD:

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -12,8 +12,9 @@ uses SimpleNamespace / dicts throughout.
 @decision DEC-AUTODEPLOY-001
 @title Policy-gated auto-deploy, conservative defaults, default OFF
 @status accepted
-@rationale Tests cover all 7 rejection branches (disabled, rule_type, syntax,
-           confidence, severity, dedup, happy path) using plain dataclasses.
+@rationale Tests cover all rejection branches (disabled, rule_type, syntax,
+           confidence, severity, dedup, happy path, sigma-specific gates)
+           using plain dataclasses.
            The function under test is pure — no DB connections, no file I/O —
            so tests are fast and deterministic regardless of environment.
 """
@@ -91,13 +92,15 @@ def test_disabled_returns_false():
 
 
 # ---------------------------------------------------------------------------
-# Test 2: rule_type='sigma' → not eligible
+# Test 2: unknown rule_type (e.g. 'suricata') → not eligible
+# Phase 2.5: sigma IS eligible (see DEC-AUTODEPLOY-003); only truly unknown
+# types should be rejected at the rule_type gate.
 # ---------------------------------------------------------------------------
 
-def test_sigma_rule_type_rejected():
-    """Sigma rules are excluded from auto-deploy in Phase 2."""
+def test_unknown_rule_type_rejected():
+    """A rule_type not in {'yara', 'sigma'} is rejected at the rule_type gate."""
     settings = _make_settings(enabled=True)
-    rule = FakeRule(rule_type="sigma")
+    rule = FakeRule(rule_type="suricata")
     decision, reason = should_auto_deploy(rule, FakeCluster(), [], settings)
     assert decision is False
     assert "rule_type" in reason
@@ -243,3 +246,88 @@ def test_purity_no_side_effects():
 
     # Inputs must not be mutated
     assert recent == []
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.5 / DEC-AUTODEPLOY-003: Sigma rule gate tests
+# ---------------------------------------------------------------------------
+
+
+def _make_sigma_settings(
+    *,
+    sigmac_available: bool = True,
+    conf_threshold: float = 0.85,
+    severities: list[str] | None = None,
+) -> SimpleNamespace:
+    """Settings with sigmac_available wired in, used for Sigma-specific tests."""
+    return SimpleNamespace(
+        AUTO_DEPLOY_ENABLED=True,
+        AUTO_DEPLOY_CONF_THRESHOLD=conf_threshold,
+        AUTO_DEPLOY_DEDUP_WINDOW_SECONDS=3600,
+        AUTO_DEPLOY_SEVERITIES=severities if severities is not None else ["Critical", "High"],
+        sigmac_available=sigmac_available,
+    )
+
+
+def test_sigma_rule_deploys_when_sigmac_available():
+    """Sigma rule with sigmac_available=True, conf=0.9, Critical → (True, 'ok')."""
+    settings = _make_sigma_settings(sigmac_available=True)
+    rule = FakeRule(rule_type="sigma", syntax_valid=True)
+    cluster = FakeCluster(ai_confidence=0.9, ai_severity="Critical")
+
+    decision, reason = should_auto_deploy(rule, cluster, [], settings)
+
+    assert decision is True, f"Expected True, got False with reason={reason!r}"
+    assert reason == "ok"
+
+
+def test_sigma_rule_skipped_when_sigmac_unavailable():
+    """Sigma rule with sigmac_available=False → (False, 'sigmac not available')."""
+    settings = _make_sigma_settings(sigmac_available=False)
+    rule = FakeRule(rule_type="sigma", syntax_valid=True)
+    cluster = FakeCluster(ai_confidence=0.9, ai_severity="Critical")
+
+    decision, reason = should_auto_deploy(rule, cluster, [], settings)
+
+    assert decision is False
+    assert reason == "sigmac not available"
+
+
+def test_sigma_rule_respects_confidence_threshold():
+    """Sigma rule with conf=0.5 (below 0.85 threshold) → (False, 'confidence below threshold')."""
+    settings = _make_sigma_settings(sigmac_available=True, conf_threshold=0.85)
+    rule = FakeRule(rule_type="sigma", syntax_valid=True)
+    cluster = FakeCluster(ai_confidence=0.5, ai_severity="Critical")
+
+    decision, reason = should_auto_deploy(rule, cluster, [], settings)
+
+    assert decision is False
+    assert reason == "confidence below threshold"
+
+
+def test_sigma_rule_respects_severity_allowlist():
+    """Sigma rule with severity=Medium (not in allowlist) → (False, 'severity not in allowlist')."""
+    settings = _make_sigma_settings(sigmac_available=True)
+    rule = FakeRule(rule_type="sigma", syntax_valid=True)
+    cluster = FakeCluster(ai_confidence=0.9, ai_severity="Medium")
+
+    decision, reason = should_auto_deploy(rule, cluster, [], settings)
+
+    assert decision is False
+    assert reason == "severity not in allowlist"
+
+
+def test_sigma_rule_respects_none_confidence_guard():
+    """Sigma rule with ai_confidence=None → (False, 'confidence not set').
+
+    DEC-AUTODEPLOY-002 applies equally to Sigma rules. Must not raise TypeError.
+    """
+    settings = _make_sigma_settings(sigmac_available=True)
+    rule = FakeRule(rule_type="sigma", syntax_valid=True)
+    cluster = FakeCluster(ai_confidence=None)
+
+    # Must not raise
+    decision, reason = should_auto_deploy(rule, cluster, [], settings)
+
+    assert decision is False
+    assert reason == "confidence not set", f"Expected 'confidence not set', got {reason!r}"

--- a/tests/test_sigma_auto_deploy.py
+++ b/tests/test_sigma_auto_deploy.py
@@ -1,0 +1,238 @@
+"""
+Sigma auto-deploy integration tests — verifies that _run_auto_deploy routes
+Sigma rules through sigmac.convert and handles conversion failures correctly.
+
+Uses an in-memory SQLite DB and tmp_path for RULES_DIR.  sigmac.convert is
+mocked because it is an external subprocess boundary (sigma-cli); all other
+internal modules (policy gate, DB helpers, orchestrator loop logic) are
+exercised against real implementations.
+
+# @mock-exempt: sigmac.convert shells out to sigma-cli — an external process
+# boundary.  This is the only mock in the file; all internal logic is real.
+
+@decision DEC-AUTODEPLOY-003
+@title Sigma now auto-deploys when sigmac_available=True
+@status accepted
+@rationale These integration tests exercise the full _run_auto_deploy path for
+           Sigma rules: happy-path conversion produces an XML file + audit row;
+           SigmaConversionError records a 'skipped' row before propagating so
+           the failure is always auditable.  The skipped-row-before-exception
+           contract is critical — the outer try/except in _run_auto_deploy would
+           otherwise swallow a conversion failure with no audit trail.
+
+Test cases:
+  1. test_sigma_auto_deploy_happy_path       — sigmac.convert succeeds →
+       XML file written, mark_rule_deployed called, deploy_events action='auto-deploy'.
+  2. test_sigma_auto_deploy_records_skipped_on_conversion_failure — sigmac.convert
+       raises SigmaConversionError → no file written, no mark_rule_deployed,
+       deploy_events action='skipped' with reason containing 'sigmac conversion failed',
+       WARNING logged, loop continues to next rule.
+"""
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.models import (
+    init_db,
+    insert_rule,
+    list_deploy_events,
+    update_cluster_ai,
+    upsert_cluster,
+)
+from agent.orchestrator import _run_auto_deploy
+from agent.sigmac import SigmaConversionError
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db():
+    """Return a fresh in-memory SQLite connection with the full schema."""
+    return init_db(":memory:")
+
+
+def _make_settings(
+    *,
+    enabled: bool = True,
+    conf_threshold: float = 0.85,
+    dedup_window: int = 3600,
+    severities: list[str] | None = None,
+    rules_dir: str | Path = "/rules",
+    sigmac_available: bool = True,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        AUTO_DEPLOY_ENABLED=enabled,
+        AUTO_DEPLOY_CONF_THRESHOLD=conf_threshold,
+        AUTO_DEPLOY_DEDUP_WINDOW_SECONDS=dedup_window,
+        AUTO_DEPLOY_SEVERITIES=severities if severities is not None else ["Critical", "High"],
+        rules_dir=str(rules_dir),
+        sigmac_available=sigmac_available,
+    )
+
+
+def _seed_cluster(
+    conn,
+    cluster_id: str,
+    src_ip: str = "10.0.0.42",
+    rule_id: int = 5501,
+    ai_severity: str = "Critical",
+    ai_confidence: float = 0.9,
+) -> None:
+    upsert_cluster(
+        conn,
+        cluster_id=cluster_id,
+        src_ip=src_ip,
+        rule_id=rule_id,
+        window_start="2026-01-01T00:00:00",
+        window_end="2026-01-01T00:05:00",
+        alert_count=3,
+        source="wazuh",
+    )
+    update_cluster_ai(conn, cluster_id, ai_severity, "Test analysis.", ai_confidence)
+
+
+def _seed_sigma_rule(
+    conn,
+    cluster_id: str,
+    rule_id: str = "sigma-rule-001",
+    syntax_valid: bool = True,
+    content: str = "title: Test\nstatus: test\ndetection:\n  selection:\n    EventID: 4625\n  condition: selection\n",
+) -> str:
+    insert_rule(
+        conn,
+        rule_id=rule_id,
+        cluster_id=cluster_id,
+        rule_type="sigma",
+        rule_content=content,
+        syntax_valid=syntax_valid,
+    )
+    return rule_id
+
+
+# ---------------------------------------------------------------------------
+# Case 1: Happy path — sigmac.convert succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_sigma_auto_deploy_happy_path(tmp_path):
+    """When sigmac.convert succeeds, the XML file is written and audit row recorded."""
+    conn = _make_db()
+    cluster_id = "cluster-sigma-happy"
+    rule_id = "sigma-rule-happy-001"
+    sigma_yaml = "title: HappyTest\nstatus: test\ndetection:\n  selection:\n    EventID: 4625\n  condition: selection\n"
+    xml_content = "<group name='test'><rule id='100001' level='12'><description>HappyTest</description></rule></group>"
+
+    _seed_cluster(conn, cluster_id, ai_severity="Critical", ai_confidence=0.9)
+    _seed_sigma_rule(conn, cluster_id, rule_id=rule_id, syntax_valid=True, content=sigma_yaml)
+
+    config = _make_settings(enabled=True, conf_threshold=0.85, rules_dir=tmp_path, sigmac_available=True)
+
+    # Mock sigmac.convert to write the XML and return the path, as the real impl does.
+    expected_xml_path = tmp_path / f"sigma_{rule_id}.xml"
+
+    def fake_convert(yaml_content, rid, rdir):
+        out = Path(rdir) / f"sigma_{rid}.xml"
+        out.write_text(xml_content, encoding="utf-8")
+        return out
+
+    with patch("agent.orchestrator._sigmac.convert", side_effect=fake_convert) as mock_convert:
+        _run_auto_deploy(conn, cluster_id, config)
+
+    # sigmac.convert was called once with correct args
+    mock_convert.assert_called_once_with(sigma_yaml, rule_id, tmp_path)
+
+    # XML file written at RULES_DIR/sigma_<rule_id>.xml
+    assert expected_xml_path.exists(), f"Expected XML at {expected_xml_path}"
+    assert expected_xml_path.read_text(encoding="utf-8") == xml_content
+
+    # deploy_events row: action='auto-deploy', rule_type='sigma'
+    events = [dict(e) for e in list_deploy_events(conn)]
+    assert len(events) == 1, f"Expected 1 deploy event, got {len(events)}: {events}"
+    evt = events[0]
+    assert evt["action"] == "auto-deploy", f"Expected action='auto-deploy', got {evt['action']!r}"
+    assert evt["rule_type"] == "sigma", f"Expected rule_type='sigma', got {evt['rule_type']!r}"
+    assert evt["reason"] == "ok"
+    assert evt["actor"] == "orchestrator"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Case 2: Conversion failure — skipped row written, loop continues
+# ---------------------------------------------------------------------------
+
+
+def test_sigma_auto_deploy_records_skipped_on_conversion_failure(tmp_path, caplog):
+    """SigmaConversionError → skipped row written BEFORE exception propagates; loop continues.
+
+    This test uses two rules: rule-fail (conversion raises) and rule-yara (YARA,
+    should deploy normally).  Verifies:
+      - No file for rule-fail
+      - deploy_events action='skipped' with 'sigmac conversion failed' in reason for rule-fail
+      - WARNING logged containing rule-fail's ID
+      - YARA rule-yara is still evaluated and deployed (loop continued)
+    """
+    conn = _make_db()
+    cluster_id = "cluster-sigma-fail"
+
+    _seed_cluster(conn, cluster_id, ai_severity="Critical", ai_confidence=0.9)
+
+    # Rule 1: Sigma rule whose conversion will fail
+    sigma_rule_id = "sigma-rule-fail-001"
+    _seed_sigma_rule(conn, cluster_id, rule_id=sigma_rule_id, syntax_valid=True)
+
+    # Rule 2: YARA rule that should still deploy after the Sigma failure
+    yara_rule_id = "yara-rule-continue-001"
+    yara_content = 'rule ContinueRule { strings: $s = "continue" condition: $s }'
+    insert_rule(
+        conn,
+        rule_id=yara_rule_id,
+        cluster_id=cluster_id,
+        rule_type="yara",
+        rule_content=yara_content,
+        syntax_valid=True,
+    )
+
+    config = _make_settings(enabled=True, conf_threshold=0.85, rules_dir=tmp_path, sigmac_available=True)
+
+    with patch(
+        "agent.orchestrator._sigmac.convert",
+        side_effect=SigmaConversionError("sigma-cli not found"),
+    ):
+        with caplog.at_level(logging.WARNING, logger="agent.orchestrator"):
+            _run_auto_deploy(conn, cluster_id, config)
+
+    # No XML file for the failed Sigma rule
+    sigma_xml = tmp_path / f"sigma_{sigma_rule_id}.xml"
+    assert not sigma_xml.exists(), f"No XML file expected for failed conversion: {sigma_xml}"
+
+    events = [dict(e) for e in list_deploy_events(conn)]
+
+    # Skipped row for the Sigma rule
+    skipped = [e for e in events if e["action"] == "skipped" and e["rule_type"] == "sigma"]
+    assert len(skipped) == 1, f"Expected 1 skipped sigma event, got: {events}"
+    assert "sigmac conversion failed" in skipped[0]["reason"], (
+        f"Expected 'sigmac conversion failed' in reason, got: {skipped[0]['reason']!r}"
+    )
+
+    # WARNING logged with the rule_id
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(sigma_rule_id in msg for msg in warning_msgs), (
+        f"Expected WARNING containing {sigma_rule_id!r}, got: {warning_msgs}"
+    )
+
+    # Loop continued: YARA rule was evaluated and deployed
+    yara_deployed = [e for e in events if e["action"] == "auto-deploy" and e["rule_type"] == "yara"]
+    assert len(yara_deployed) == 1, (
+        f"Expected YARA rule to deploy after Sigma failure, got events: {events}"
+    )
+    yara_file = tmp_path / f"{yara_rule_id}.yar"
+    assert yara_file.exists(), f"Expected YARA file at {yara_file}"
+
+    conn.close()


### PR DESCRIPTION
Closes #26 (REQ-P0-P25-002). Last P0 ticket for Phase 2.5.

## Summary
Wave B of Phase 2.5. Lifts the YARA-only ceiling on auto-deploy: Sigma rules now flow through the same policy gate and out to disk as Wazuh-native XML, using the sigmac wrapper (#24) and startup probe (#25) landed in Wave A.

- **Policy gate expansion** (`agent/policy.py`): rule_type gate accepts `yara` + `sigma` via `_ELIGIBLE_RULE_TYPES`. Sigma additionally requires `settings.sigmac_available`. Gate stays pure — attribute reads only, no subprocess. `@decision DEC-AUTODEPLOY-003` documents the expansion.
- **Orchestrator routing** (`agent/orchestrator.py` `_run_auto_deploy`): Sigma rules call `sigmac.convert()` before file drop. `SigmaConversionError` triggers a WARNING log + `deploy_events` row with `action='skipped'` written **inside the except clause before `continue`** — a subtle but important audit-trail contract. Without it, the outer catch-all swallows the failure without a trail.
- **Tests** (+7 new, 1 renamed, 0 regressions): 5 policy-gate cases for the Sigma paths, 2 live integration tests driving `_run_auto_deploy` against real in-memory SQLite (sigmac mocked at subprocess boundary only).

## Audit-trail contract
Live integration probe confirmed end-to-end (not just via test mock setup):
- 2 rules (one sigma, one yara) → sigmac fails on sigma → DB has `skipped` row with reason `sigmac conversion failed: sigma-cli not found` + `auto-deploy` row for yara
- No XML file written for failed sigma
- Loop continued past sigma failure; yara `.yar` file written
- WARNING emitted with rule_id and cluster_id

## Test plan
- [x] `pytest tests/` — 130 passed, 1 skipped (real-sigma guarded), 0 regressions
- [x] Live integration probe with real SQLite — audit row present, loop continuation confirmed, filesystem state matches expectations
- [x] `grep 'DEC-AUTODEPLOY-003'` — present in both policy.py and orchestrator.py (as cross-ref)
- [x] Policy gate purity — no subprocess/I/O in executable lines of `should_auto_deploy`
- [ ] Manual: with sigma-cli installed, trigger a real Sigma auto-deploy end-to-end and verify XML at `/rules/sigma_<id>.xml`

## Notes
- Phase 2.5 is now functionally complete with this PR. Remaining ticket #27 is the no-regression merge gate, implicit in this PR's test suite (check ran clean).
- **Do not auto-merge.** Leave open for review.
- Once this lands, MASTER_PLAN.md Phase 2.5 should flip from `in-progress` to `completed` on a small docs PR. Phase 3 (Immune System) becomes the next actionable phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)