### PR TITLE
feat(#34): canary tokens + /canary routes (REQ-P0-P3-004)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,13 @@ AUTO_DEPLOY_SEVERITIES=["Critical","High"]
 URLHAUS_FEED_URL=https://urlhaus.abuse.ch/downloads/csv_online/
 # How often to refresh the threat_intel table from the feed (seconds). Default: 3600 (hourly).
 URLHAUS_FETCH_INTERVAL_SECONDS=3600
+
+# --- Phase 3: Canary tokens (REQ-P0-P3-004) ---
+# Base URL used to build HTTP canary trap URLs returned by POST /canary/spawn.
+# Override with the public hostname/IP where Shaferhund is reachable so external
+# attackers can hit the /canary/hit/{token} route.
+CANARY_BASE_URL=http://127.0.0.1:8000
+# Base hostname suffix for DNS canary trap hostnames ({token}.{CANARY_BASE_HOSTNAME}).
+# For DNS traps to fire, configure a wildcard DNS record pointing to your sensor
+# or enable Wazuh DNS query monitoring on the canary.local zone.
+CANARY_BASE_HOSTNAME=canary.local

--- a/agent/canary.py
+++ b/agent/canary.py
@@ -1,0 +1,408 @@
+"""
+Canary token infrastructure for Shaferhund Phase 3 (REQ-P0-P3-004).
+
+Provides DNS and HTTP trap tokens that, when triggered by an attacker probing
+the environment, inject ``source='canary'`` alert rows into the shared alert
+pipeline. Those alerts flow through the clusterer, triage queue, and
+orchestrator identically to Wazuh and Suricata alerts.
+
+Spawn flow:
+    POST /canary/spawn → spawn_canary() → canary_tokens row → trap URL/hostname
+
+Hit flow:
+    GET /canary/hit/{token} → record_hit() → increment trigger_count →
+    write alert row with source='canary' → clusterer → triage
+
+Security notes:
+  - token is generated with secrets.token_urlsafe(16) (128 bits of entropy).
+  - request_meta keys (User-Agent, X-Forwarded-For, etc.) are attacker-controlled;
+    all values passed to the alert row are sanitized via sanitize_alert_field().
+  - The name param to spawn_canary() is operator-controlled but is also sanitized
+    as a defence-in-depth measure.
+
+@decision DEC-CANARY-001
+@title Canary tokens use secrets.token_urlsafe(16) for 128-bit entropy
+@status accepted
+@rationale Tokens are embedded in public trap URLs / hostnames. 16 bytes of
+           cryptographic randomness (≈ 22 base64 chars) gives 2^128 entropy,
+           making brute-force guessing impractical. secrets module is stdlib —
+           no external dependency. URL-safe alphabet avoids percent-encoding
+           issues in trap URLs and DNS labels.
+
+@decision DEC-CANARY-002
+@title Canary hits inject source='canary' alerts via the shared _persist_and_enqueue path
+@status accepted
+@rationale Canary hits are threats just like Wazuh or Suricata alerts — they
+           deserve the same clustering, triage, and rule-generation pipeline.
+           Routing them through the same entry point (Cluster → TriageQueue →
+           orchestrator) means canary alerts automatically get AI triage and
+           can trigger YARA/Sigma rule generation. A separate pipeline would
+           duplicate logic and create a maintenance burden. The alert id uses a
+           'canary:' prefix so dedup works without colliding with Wazuh IDs.
+
+@decision DEC-CANARY-003
+@title spawn_canary and record_hit are pure DB helpers; HTTP wiring lives in main.py
+@status accepted
+@rationale Keeping network concerns (request parsing, response formatting) in
+           main.py and persistence concerns here follows the same separation
+           used for threat_intel.py vs main.py. This makes record_hit testable
+           without a running FastAPI app — tests call it directly with a
+           fabricated request_meta dict and an in-memory connection.
+"""
+
+import logging
+import secrets
+import sqlite3
+from datetime import datetime, timezone
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sanitization
+# ---------------------------------------------------------------------------
+
+_MAX_FIELD_LEN = 1024
+
+
+def sanitize_alert_field(value: str) -> str:
+    """Sanitize an attacker- or operator-controlled string for safe storage.
+
+    Strips leading/trailing whitespace and truncates to _MAX_FIELD_LEN
+    characters. Does NOT strip non-printable characters — the raw value
+    may be useful for forensics — but keeps the field bounded to prevent
+    storage abuse.
+
+    Args:
+        value: Input string (may be attacker-controlled).
+
+    Returns:
+        Sanitized string, at most _MAX_FIELD_LEN characters.
+    """
+    if not isinstance(value, str):
+        value = str(value)
+    return value.strip()[:_MAX_FIELD_LEN]
+
+
+# ---------------------------------------------------------------------------
+# Canary token CRUD
+# ---------------------------------------------------------------------------
+
+def insert_canary_token(
+    conn: sqlite3.Connection,
+    token: str,
+    token_type: str,
+    name: str,
+) -> int:
+    """Insert a new canary_tokens row and return the row id.
+
+    Args:
+        conn:       Open SQLite connection.
+        token:      Unique opaque token string (URL-safe base64).
+        token_type: 'dns' or 'http'.
+        name:       Human-readable label for this canary.
+
+    Returns:
+        The INTEGER PRIMARY KEY of the new row.
+    """
+    created_at = datetime.now(timezone.utc).isoformat()
+    with _cursor(conn) as cur:
+        cur.execute(
+            """
+            INSERT INTO canary_tokens (token, type, name, created_at, trigger_count)
+            VALUES (?, ?, ?, ?, 0)
+            """,
+            (token, token_type, name, created_at),
+        )
+        return cur.lastrowid
+
+
+def get_canary_token_by_token(
+    conn: sqlite3.Connection,
+    token: str,
+) -> Optional[sqlite3.Row]:
+    """Return the canary_tokens row for a given token string, or None.
+
+    Args:
+        conn:  Open SQLite connection.
+        token: The opaque token value to look up.
+
+    Returns:
+        sqlite3.Row or None.
+    """
+    return conn.execute(
+        "SELECT * FROM canary_tokens WHERE token = ?",
+        (token,),
+    ).fetchone()
+
+
+def increment_canary_trigger(
+    conn: sqlite3.Connection,
+    token: str,
+) -> None:
+    """Increment trigger_count and set last_triggered_at for a token.
+
+    Idempotent in the sense that repeated calls keep counting correctly.
+    Does nothing if the token does not exist.
+
+    Args:
+        conn:  Open SQLite connection.
+        token: The token that was triggered.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    with _cursor(conn) as cur:
+        cur.execute(
+            """
+            UPDATE canary_tokens
+               SET trigger_count = trigger_count + 1,
+                   last_triggered_at = ?
+             WHERE token = ?
+            """,
+            (now, token),
+        )
+
+
+def list_canary_tokens(
+    conn: sqlite3.Connection,
+    limit: int = 100,
+) -> list[sqlite3.Row]:
+    """Return canary_tokens rows ordered newest-first.
+
+    Args:
+        conn:  Open SQLite connection.
+        limit: Maximum rows to return.
+
+    Returns:
+        List of sqlite3.Row objects.
+    """
+    return conn.execute(
+        "SELECT * FROM canary_tokens ORDER BY created_at DESC LIMIT ?",
+        (limit,),
+    ).fetchall()
+
+
+def count_canary_triggers_since(
+    conn: sqlite3.Connection,
+    ts: float,
+) -> int:
+    """Count canary trigger events where last_triggered_at >= ts.
+
+    Sums trigger_count for tokens whose last_triggered_at falls within the
+    window. This is a proxy: it counts distinct tokens that were triggered
+    in the window, not total trigger events (which would require an event log).
+    For /health purposes (24h count) this is sufficient — a single token
+    triggered many times in 24h still shows as 1.
+
+    For an accurate total, sum trigger_count across all rows that were
+    last triggered within the window.
+
+    Args:
+        conn: Open SQLite connection.
+        ts:   Unix epoch float (e.g. time.time() - 86400).
+
+    Returns:
+        Integer count of trigger_count sum for tokens triggered since ts.
+    """
+    since_iso = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    row = conn.execute(
+        """
+        SELECT COALESCE(SUM(trigger_count), 0)
+          FROM canary_tokens
+         WHERE last_triggered_at >= ?
+        """,
+        (since_iso,),
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+# ---------------------------------------------------------------------------
+# Core canary operations
+# ---------------------------------------------------------------------------
+
+def spawn_canary(
+    conn: sqlite3.Connection,
+    token_type: str,
+    name: str,
+    base_url: str = "http://127.0.0.1:8000",
+    base_hostname: str = "canary.local",
+) -> dict:
+    """Create a new canary token and return spawn metadata.
+
+    Generates a cryptographically random token, inserts a canary_tokens row,
+    and returns the token along with the appropriate trap URL or hostname.
+
+    Args:
+        conn:          Open SQLite connection.
+        token_type:    'http' or 'dns'.
+        name:          Human-readable label (operator-controlled, sanitized).
+        base_url:      Base URL for HTTP traps (from CANARY_BASE_URL env var).
+        base_hostname: Base hostname for DNS traps (from CANARY_BASE_HOSTNAME).
+
+    Returns:
+        Dict with keys: id (int), token (str), type (str), name (str),
+        trap_url (str for http), trap_hostname (str for dns).
+
+    Raises:
+        ValueError: If token_type is not 'http' or 'dns'.
+    """
+    if token_type not in ("http", "dns"):
+        raise ValueError(f"token_type must be 'http' or 'dns', got {token_type!r}")
+
+    safe_name = sanitize_alert_field(name)
+    token = secrets.token_urlsafe(16)
+
+    row_id = insert_canary_token(conn, token, token_type, safe_name)
+    log.info(
+        "Canary spawned: type=%s name=%r token=%s id=%d",
+        token_type, safe_name, token, row_id,
+    )
+
+    result: dict = {
+        "id": row_id,
+        "token": token,
+        "type": token_type,
+        "name": safe_name,
+    }
+
+    if token_type == "http":
+        trap_url = f"{base_url.rstrip('/')}/canary/hit/{token}"
+        result["trap_url"] = trap_url
+    else:
+        # DNS: attacker queries <token>.<base_hostname>
+        trap_hostname = f"{token}.{base_hostname}"
+        result["trap_hostname"] = trap_hostname
+
+    return result
+
+
+def record_hit(
+    conn: sqlite3.Connection,
+    token: str,
+    request_meta: dict,
+    enqueue_fn=None,
+) -> bool:
+    """Record a canary hit and inject a source='canary' alert into the pipeline.
+
+    Looks up the token, increments the trigger counter, and constructs an alert
+    row with source='canary'. The alert is inserted directly (not via the
+    file tailer) and passed to enqueue_fn so the shared clusterer + triage
+    path picks it up.
+
+    All request_meta values are sanitized before storage (attacker-controlled).
+
+    Args:
+        conn:        Open SQLite connection.
+        token:       The token value from the trap URL.
+        request_meta: Dict of request metadata: src_ip, user_agent, path, etc.
+        enqueue_fn:  Async callable(cluster) from main.py's _persist_and_enqueue.
+                     If None, the alert is written to DB only (useful in tests
+                     that don't need live clustering).
+
+    Returns:
+        True if a known token was found and the hit recorded, False if unknown.
+    """
+    row = get_canary_token_by_token(conn, token)
+    if row is None:
+        log.warning("Canary hit for unknown token: %s", token[:40])
+        return False
+
+    # Increment the trigger counter
+    increment_canary_trigger(conn, token)
+
+    # Build a sanitized alert record
+    src_ip = sanitize_alert_field(str(request_meta.get("src_ip") or "unknown"))
+    user_agent = sanitize_alert_field(str(request_meta.get("user_agent") or ""))
+    path = sanitize_alert_field(str(request_meta.get("path") or ""))
+    canary_name = sanitize_alert_field(str(row["name"]))
+    canary_type = sanitize_alert_field(str(row["type"]))
+
+    # Unique alert id — canary: prefix avoids collision with Wazuh IDs
+    now_iso = datetime.now(timezone.utc).isoformat()
+    alert_id = f"canary:{token}:{now_iso}"
+
+    # The alert is a minimal dict; rule_id 0 is a sentinel for canary hits.
+    # Severity 10 (high): a canary hit means something is actively probing.
+    raw_alert = {
+        "id": alert_id,
+        "source": "canary",
+        "token": token,
+        "canary_name": canary_name,
+        "canary_type": canary_type,
+        "src_ip": src_ip,
+        "user_agent": user_agent,
+        "path": path,
+        "triggered_at": now_iso,
+    }
+
+    # Insert alert row directly (bypasses the file tailer)
+    from .models import insert_alert, update_alert_cluster
+    insert_alert(
+        conn,
+        alert_id=alert_id,
+        rule_id=0,
+        src_ip=src_ip,
+        severity=10,
+        raw_json=raw_alert,
+    )
+
+    # Set source column on the alert row (Phase 2 column, added idempotently)
+    with _cursor(conn) as cur:
+        cur.execute(
+            "UPDATE alerts SET source = 'canary' WHERE id = ?",
+            (alert_id,),
+        )
+
+    log.info(
+        "Canary hit recorded: token=%s src_ip=%s canary=%r",
+        token[:16], src_ip, canary_name,
+    )
+
+    # Route through the clusterer/triage pipeline if enqueue_fn was provided.
+    # enqueue_fn is async; caller is responsible for awaiting it. In practice,
+    # main.py's route handler uses asyncio.create_task to avoid blocking the
+    # response, since the hit route must return immediately (suspicion avoidance).
+    if enqueue_fn is not None:
+        import asyncio
+        from .cluster import Alert, AlertClusterer
+        alert_obj = Alert(
+            id=alert_id,
+            rule_id=0,
+            src_ip=src_ip,
+            severity=10,
+            raw=raw_alert,
+            source="canary",
+        )
+        # Wrap the enqueue call as a task so the HTTP response is not delayed
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                asyncio.ensure_future(enqueue_fn(alert_obj))
+            else:
+                loop.run_until_complete(enqueue_fn(alert_obj))
+        except RuntimeError:
+            # No event loop — test context, skip async dispatch
+            pass
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+from contextlib import contextmanager
+from typing import Generator
+
+
+@contextmanager
+def _cursor(conn: sqlite3.Connection) -> Generator[sqlite3.Cursor, None, None]:
+    """Context manager: yield cursor, commit on success, rollback on error."""
+    cur = conn.cursor()
+    try:
+        yield cur
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()

--- a/agent/config.py
+++ b/agent/config.py
@@ -71,6 +71,16 @@ class Settings(BaseSettings):
     # table. Defaults to 3600 (hourly) per MASTER_PLAN.md Phase 3 spec.
     urlhaus_fetch_interval_seconds: int = 3600
 
+    # Phase 3 — Canary tokens (REQ-P0-P3-004)
+    # Base URL for HTTP canary trap URLs. Override when Shaferhund is reachable
+    # at a public hostname so external attackers can reach the /canary/hit/{token}
+    # route. Defaults to localhost for local dev / test.
+    canary_base_url: str = "http://127.0.0.1:8000"
+    # Base hostname suffix for DNS canary traps. Tokens take the form
+    # {token}.{canary_base_hostname}. For DNS traps to fire, the hostname must
+    # be resolvable — configure a wildcard DNS record or Wazuh DNS monitoring.
+    canary_base_hostname: str = "canary.local"
+
     # Auto-deploy policy gate (Phase 2, REQ-P0-P2-006, DEC-AUTODEPLOY-001)
     # Default OFF — operator must explicitly enable via env var.
     AUTO_DEPLOY_ENABLED: bool = False

--- a/agent/main.py
+++ b/agent/main.py
@@ -97,6 +97,8 @@ from .orchestrator import get_orchestrator_stats
 from .triage import TriageResult, TriageQueue
 from . import threat_intel as _threat_intel
 from .models import count_threat_intel_records
+from . import canary as _canary
+from .canary import spawn_canary, record_hit, count_canary_triggers_since
 
 log = logging.getLogger(__name__)
 
@@ -302,11 +304,19 @@ async def health() -> JSONResponse:
                probes, which only need {status, poller_healthy} to decide liveness.
     """
     ti_count = count_threat_intel_records(_db) if _db is not None else 0
+    canary_24h = (
+        count_canary_triggers_since(_db, time.time() - 86400)
+        if _db is not None
+        else 0
+    )
     return JSONResponse({
         "status": "ok",
         "poller_healthy": _poller_healthy,
         "threat_intel": {
             "record_count": ti_count,
+        },
+        "canary": {
+            "trigger_count_24h": canary_24h,
         },
     })
 
@@ -542,6 +552,117 @@ async def undo_deploy_rule(rule_id: str):
         )
 
     return {"reverted": True, "path": str(rule_file)}
+
+
+# ---------------------------------------------------------------------------
+# Canary token routes (Phase 3, REQ-P0-P3-004)
+# ---------------------------------------------------------------------------
+
+@app.post(
+    "/canary/spawn",
+    dependencies=[Depends(_require_auth)],
+)
+async def canary_spawn(request: Request) -> JSONResponse:
+    """Spawn a new DNS or HTTP canary token.
+
+    Auth-gated (same SHAFERHUND_TOKEN bearer scheme as /metrics).
+
+    Request body JSON:
+        type (str): 'dns' or 'http'
+        name (str): human-readable label for this canary
+
+    Returns:
+        JSON with: id, token, type, name, and either trap_url (http)
+        or trap_hostname (dns).
+    """
+    if _db is None or _settings is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+
+    token_type = body.get("type", "")
+    name = body.get("name", "")
+
+    if token_type not in ("dns", "http"):
+        raise HTTPException(
+            status_code=422,
+            detail="type must be 'dns' or 'http'",
+        )
+    if not isinstance(name, str) or not name.strip():
+        raise HTTPException(status_code=422, detail="name must be a non-empty string")
+
+    try:
+        result = spawn_canary(
+            _db,
+            token_type=token_type,
+            name=name,
+            base_url=_settings.canary_base_url,
+            base_hostname=_settings.canary_base_hostname,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return JSONResponse(result, status_code=201)
+
+
+@app.get("/canary/hit/{token}")
+async def canary_hit(token: str, request: Request) -> JSONResponse:
+    """Public trap endpoint — no auth required.
+
+    Called when an attacker follows an HTTP canary link. Returns an innocuous
+    response (200 with minimal body) to avoid tipping off the attacker that
+    they hit a trap. The real work happens in record_hit() which writes a
+    source='canary' alert row and routes it through the clusterer/triage pipeline.
+
+    The /canary/hit path is intentionally NOT behind _require_auth: an attacker
+    won't send a bearer token, and requiring auth would make the trap useless.
+    """
+    if _db is None:
+        # DB not ready — still return innocuous 200 to avoid fingerprinting
+        return JSONResponse({"ok": True})
+
+    # Extract sanitized request metadata (all attacker-controlled)
+    forwarded_for = request.headers.get("x-forwarded-for", "")
+    client_ip = (
+        forwarded_for.split(",")[0].strip()
+        if forwarded_for
+        else (request.client.host if request.client else "unknown")
+    )
+    request_meta = {
+        "src_ip": client_ip,
+        "user_agent": request.headers.get("user-agent", ""),
+        "path": str(request.url.path),
+        "x_forwarded_for": forwarded_for,
+    }
+
+    hit = record_hit(
+        _db,
+        token=token,
+        request_meta=request_meta,
+        enqueue_fn=_canary_enqueue,
+    )
+
+    # Always return innocuous 200 regardless of whether the token was known.
+    # A 404 for unknown tokens would let an attacker enumerate valid tokens.
+    return JSONResponse({"ok": True})
+
+
+async def _canary_enqueue(alert_obj) -> None:
+    """Bridge between record_hit() and the shared clusterer/triage pipeline.
+
+    record_hit() calls this with an Alert object. We add it to the shared
+    AlertClusterer (which may close a cluster) and persist + enqueue any
+    closed clusters for triage.
+    """
+    if _clusterer is None or _db is None:
+        return
+
+    closed = _clusterer.add(alert_obj)
+    for cluster in closed:
+        await _persist_and_enqueue(cluster)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/models.py
+++ b/agent/models.py
@@ -175,6 +175,39 @@ CREATE INDEX IF NOT EXISTS idx_threat_intel_type
 """
 
 
+
+# ---------------------------------------------------------------------------
+# Phase 3 schema additions — canary_tokens table (REQ-P0-P3-004)
+# ---------------------------------------------------------------------------
+#
+# Created with CREATE TABLE IF NOT EXISTS — idempotent for Phase 1/2/2.5/3
+# databases (per DEC-SCHEMA-002).
+#
+# Columns:
+#   token             — opaque URL-safe base64 string embedded in trap URL/hostname.
+#   type              — 'dns' or 'http'; CHECK constraint enforced at DB level.
+#   name              — operator-supplied label for this canary.
+#   created_at        — ISO8601 timestamp when the token was spawned.
+#   trigger_count     — number of times the trap has been hit (accumulated).
+#   last_triggered_at — ISO8601 timestamp of the most recent hit (NULL until first hit).
+_CANARY_TOKENS_SQL = """
+CREATE TABLE IF NOT EXISTS canary_tokens (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    token             TEXT    NOT NULL UNIQUE,
+    type              TEXT    NOT NULL CHECK(type IN ('dns', 'http')),
+    name              TEXT    NOT NULL DEFAULT '',
+    created_at        TEXT    NOT NULL,
+    trigger_count     INTEGER NOT NULL DEFAULT 0,
+    last_triggered_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_canary_tokens_token
+    ON canary_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_canary_tokens_last_triggered
+    ON canary_tokens(last_triggered_at);
+"""
+
+
 def init_db(db_path: str) -> sqlite3.Connection:
     """Open (or create) the SQLite database and apply schema.
 
@@ -234,6 +267,9 @@ def init_db(db_path: str) -> sqlite3.Connection:
 
     # threat_intel table (Phase 3, REQ-P0-P3-005) — idempotent.
     conn.executescript(_THREAT_INTEL_SQL)
+
+    # canary_tokens table (Phase 3, REQ-P0-P3-004) — idempotent.
+    conn.executescript(_CANARY_TOKENS_SQL)
 
     conn.commit()
     log.info("Database initialised at %s", db_path)

--- a/tests/test_canary.py
+++ b/tests/test_canary.py
@@ -1,0 +1,386 @@
+"""
+Canary token tests (Phase 3, REQ-P0-P3-004).
+
+Tests cover:
+  1. test_spawn_http_canary_creates_db_row  — HTTP canary: DB row inserted, trap_url shape
+  2. test_spawn_dns_canary_creates_db_row   — DNS canary: DB row inserted, trap_hostname shape
+  3. test_spawn_invalid_type_raises         — ValueError on bad type param
+  4. test_hit_records_alert_row             — GET /canary/hit/{token} → alert in DB with source='canary'
+  5. test_hit_increments_trigger_count      — trigger_count increments, last_triggered_at set
+  6. test_hit_invalid_token_no_db_mutation  — unknown token → innocuous 200, no DB changes
+  7. test_spawn_auth_gate_401_no_token      — POST /canary/spawn requires auth when token set
+  8. test_spawn_auth_gate_200_with_token    — POST /canary/spawn → 201 with correct bearer
+  9. test_health_includes_canary_field      — GET /health has canary.trigger_count_24h
+  10. test_count_canary_triggers_since       — count_canary_triggers_since returns correct int
+  11. test_spawn_name_sanitized             — overly long name is truncated before storage
+  12. test_canary_hit_sanitizes_user_agent  — attacker user-agent value stored safely (truncated)
+
+# @mock-exempt: No external HTTP boundaries are mocked here. All tests use either
+# the in-memory SQLite DB (via init_db(":memory:")) or FastAPI TestClient with
+# module-level singletons patched — same pattern as test_health.py and test_dashboard.py.
+"""
+
+import sqlite3
+import time
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+from fastapi.testclient import TestClient
+
+import agent.main as main_module
+from agent.canary import (
+    count_canary_triggers_since,
+    get_canary_token_by_token,
+    increment_canary_trigger,
+    insert_canary_token,
+    list_canary_tokens,
+    record_hit,
+    spawn_canary,
+)
+from agent.models import init_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_db() -> sqlite3.Connection:
+    """In-memory SQLite DB with full Phase 3 schema (including canary_tokens)."""
+    return init_db(":memory:")
+
+
+def _make_settings(tmp_path, token: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        shaferhund_token=token,
+        rules_dir=str(tmp_path / "rules"),
+        db_path=":memory:",
+        alerts_file="/dev/null",
+        suricata_eve_file="/dev/null",
+        triage_hourly_budget=20,
+        AUTO_DEPLOY_ENABLED=False,
+        sigmac_available=False,
+        sigmac_version=None,
+        canary_base_url="http://127.0.0.1:8000",
+        canary_base_hostname="canary.local",
+    )
+
+
+def _make_client(tmp_path, token: str = ""):
+    """Return (TestClient, conn) with module singletons patched."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir(exist_ok=True)
+
+    conn = _fresh_db()
+    settings = _make_settings(tmp_path, token=token)
+
+    main_module._db = conn
+    main_module._settings = settings
+    main_module._triage_queue = None
+    main_module._clusterer = None
+    main_module._poller_healthy = False
+    main_module._last_poll_at = None
+
+    client = TestClient(main_module.app, raise_server_exceptions=True)
+    return client, conn
+
+
+# ---------------------------------------------------------------------------
+# Test 1: spawn_http_canary — DB row + trap_url shape
+# ---------------------------------------------------------------------------
+
+def test_spawn_http_canary_creates_db_row():
+    """spawn_canary('http') inserts a canary_tokens row and returns trap_url."""
+    conn = _fresh_db()
+
+    result = spawn_canary(conn, token_type="http", name="test-http-canary")
+
+    assert "token" in result
+    assert "trap_url" in result
+    assert result["type"] == "http"
+    assert result["name"] == "test-http-canary"
+    assert isinstance(result["id"], int)
+
+    # trap_url must contain the token
+    assert result["token"] in result["trap_url"]
+    assert "/canary/hit/" in result["trap_url"]
+
+    # DB row must exist
+    row = get_canary_token_by_token(conn, result["token"])
+    assert row is not None
+    assert row["type"] == "http"
+    assert row["trigger_count"] == 0
+    assert row["last_triggered_at"] is None
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: spawn_dns_canary — DB row + trap_hostname shape
+# ---------------------------------------------------------------------------
+
+def test_spawn_dns_canary_creates_db_row():
+    """spawn_canary('dns') inserts a canary_tokens row and returns trap_hostname."""
+    conn = _fresh_db()
+
+    result = spawn_canary(
+        conn,
+        token_type="dns",
+        name="test-dns-canary",
+        base_hostname="canary.local",
+    )
+
+    assert "token" in result
+    assert "trap_hostname" in result
+    assert "trap_url" not in result
+    assert result["type"] == "dns"
+    assert result["trap_hostname"].startswith(result["token"])
+    assert result["trap_hostname"].endswith(".canary.local")
+
+    row = get_canary_token_by_token(conn, result["token"])
+    assert row is not None
+    assert row["type"] == "dns"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: invalid type raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_spawn_invalid_type_raises():
+    """spawn_canary raises ValueError for unsupported token_type."""
+    conn = _fresh_db()
+
+    with pytest.raises(ValueError, match="token_type must be"):
+        spawn_canary(conn, token_type="smtp", name="bad-type")
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: GET /canary/hit/{token} → alert row in DB with source='canary'
+# ---------------------------------------------------------------------------
+
+def test_hit_records_alert_row(tmp_path):
+    """Hitting a canary trap URL writes a source='canary' row to the alerts table."""
+    client, conn = _make_client(tmp_path)
+
+    # Spawn an HTTP canary
+    spawned = spawn_canary(conn, "http", "hit-test-canary")
+    token = spawned["token"]
+
+    resp = client.get(f"/canary/hit/{token}")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    # Alert row should exist with source='canary'
+    rows = conn.execute(
+        "SELECT * FROM alerts WHERE source = 'canary'"
+    ).fetchall()
+    assert len(rows) >= 1, "Expected at least one canary alert row"
+
+    alert = dict(rows[0])
+    assert alert["source"] == "canary"
+
+    # raw_json should contain the canary-specific fields
+    import json
+    raw = json.loads(
+        conn.execute(
+            "SELECT raw_json FROM alert_details WHERE alert_id = ?",
+            (alert["id"],),
+        ).fetchone()["raw_json"]
+    )
+    assert raw["source"] == "canary"
+    assert raw["token"] == token
+
+
+# ---------------------------------------------------------------------------
+# Test 5: trigger_count increments and last_triggered_at is set
+# ---------------------------------------------------------------------------
+
+def test_hit_increments_trigger_count(tmp_path):
+    """After a canary hit, trigger_count == 1 and last_triggered_at is not None."""
+    client, conn = _make_client(tmp_path)
+
+    spawned = spawn_canary(conn, "http", "count-test")
+    token = spawned["token"]
+
+    # Verify initial state
+    row_before = get_canary_token_by_token(conn, token)
+    assert row_before["trigger_count"] == 0
+    assert row_before["last_triggered_at"] is None
+
+    client.get(f"/canary/hit/{token}")
+
+    row_after = get_canary_token_by_token(conn, token)
+    assert row_after["trigger_count"] == 1
+    assert row_after["last_triggered_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 6: unknown token → innocuous 200, no DB mutations
+# ---------------------------------------------------------------------------
+
+def test_hit_invalid_token_no_db_mutation(tmp_path):
+    """Unknown token returns innocuous 200 and leaves the DB unchanged."""
+    client, conn = _make_client(tmp_path)
+
+    alert_count_before = conn.execute("SELECT COUNT(*) FROM alerts").fetchone()[0]
+
+    resp = client.get("/canary/hit/notavalidtoken12345")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    alert_count_after = conn.execute("SELECT COUNT(*) FROM alerts").fetchone()[0]
+    assert alert_count_after == alert_count_before, (
+        "Unknown token hit must not insert alert rows"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: POST /canary/spawn requires auth when token is set (401 without header)
+# ---------------------------------------------------------------------------
+
+def test_spawn_auth_gate_401_no_token(tmp_path):
+    """POST /canary/spawn → 401 when SHAFERHUND_TOKEN is set and no bearer provided."""
+    client, conn = _make_client(tmp_path, token="secret999")
+
+    resp = client.post("/canary/spawn", json={"type": "http", "name": "auth-test"})
+    assert resp.status_code == 401, (
+        f"Expected 401 for unauthenticated /canary/spawn, got {resp.status_code}"
+    )
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: POST /canary/spawn → 201 with correct bearer
+# ---------------------------------------------------------------------------
+
+def test_spawn_auth_gate_200_with_token(tmp_path):
+    """POST /canary/spawn → 201 with correct bearer token when auth is configured."""
+    client, conn = _make_client(tmp_path, token="secret999")
+
+    resp = client.post(
+        "/canary/spawn",
+        json={"type": "http", "name": "auth-ok-test"},
+        headers={"Authorization": "Bearer secret999"},
+    )
+    assert resp.status_code == 201, (
+        f"Expected 201 from /canary/spawn with valid token, got {resp.status_code}"
+    )
+
+    data = resp.json()
+    assert "token" in data
+    assert "trap_url" in data
+    assert data["type"] == "http"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 9: GET /health includes canary.trigger_count_24h
+# ---------------------------------------------------------------------------
+
+def test_health_includes_canary_field(tmp_path):
+    """GET /health response includes canary.trigger_count_24h (int)."""
+    client, conn = _make_client(tmp_path)
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert "canary" in data, f"'canary' key missing from /health: {data.keys()}"
+    assert "trigger_count_24h" in data["canary"], (
+        f"'trigger_count_24h' missing from canary block: {data['canary']}"
+    )
+    assert isinstance(data["canary"]["trigger_count_24h"], int)
+
+    # threat_intel must still be present (no regression)
+    assert "threat_intel" in data, "'threat_intel' key removed from /health — regression"
+    assert "record_count" in data["threat_intel"]
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 10: count_canary_triggers_since returns correct count
+# ---------------------------------------------------------------------------
+
+def test_count_canary_triggers_since():
+    """count_canary_triggers_since sums trigger_count for recently-triggered tokens."""
+    conn = _fresh_db()
+
+    # Spawn two tokens and hit each once
+    s1 = spawn_canary(conn, "http", "canary-a")
+    s2 = spawn_canary(conn, "http", "canary-b")
+
+    increment_canary_trigger(conn, s1["token"])
+    increment_canary_trigger(conn, s2["token"])
+
+    # Both were triggered now — should appear in the 24h window
+    count = count_canary_triggers_since(conn, time.time() - 86400)
+    assert count == 2, f"Expected 2 triggers in 24h window, got {count}"
+
+    # Future anchor — nothing triggered after this moment yet
+    count_future = count_canary_triggers_since(conn, time.time() + 3600)
+    assert count_future == 0, f"Expected 0 triggers in future window, got {count_future}"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 11: name is sanitized (truncated to _MAX_FIELD_LEN)
+# ---------------------------------------------------------------------------
+
+def test_spawn_name_sanitized():
+    """Very long name is truncated before being stored in canary_tokens."""
+    conn = _fresh_db()
+
+    long_name = "x" * 2000
+    result = spawn_canary(conn, "http", long_name)
+
+    # The stored name must be at most 1024 chars
+    row = get_canary_token_by_token(conn, result["token"])
+    assert len(row["name"]) <= 1024, (
+        f"name not truncated: stored {len(row['name'])} chars"
+    )
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 12: attacker-controlled user-agent is sanitized (truncated)
+# ---------------------------------------------------------------------------
+
+def test_canary_hit_sanitizes_user_agent():
+    """record_hit() truncates oversized user-agent before writing to the alert row."""
+    conn = _fresh_db()
+
+    spawned = spawn_canary(conn, "http", "ua-sanitize-test")
+    token = spawned["token"]
+
+    evil_ua = "A" * 5000  # massively oversized
+    request_meta = {
+        "src_ip": "10.0.0.1",
+        "user_agent": evil_ua,
+        "path": "/canary/hit/" + token,
+    }
+
+    hit = record_hit(conn, token, request_meta, enqueue_fn=None)
+    assert hit is True
+
+    # Retrieve raw alert and check user_agent length
+    import json
+    raw_row = conn.execute(
+        "SELECT raw_json FROM alert_details WHERE alert_id LIKE 'canary:%'"
+    ).fetchone()
+    assert raw_row is not None
+    raw = json.loads(raw_row["raw_json"])
+    assert len(raw.get("user_agent", "")) <= 1024, (
+        "user_agent not truncated in stored alert"
+    )
+
+    conn.close()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -136,10 +136,11 @@ def _make_config(max_calls: int = 5, wall_timeout: float = 10.0) -> SimpleNamesp
 
 
 def test_health_returns_only_liveness_fields(tmp_path):
-    """GET /health → exactly {status, poller_healthy, threat_intel}, nothing else.
+    """GET /health → exactly {status, poller_healthy, threat_intel, canary}, nothing else.
 
     Phase 3 (REQ-P0-P3-005) added threat_intel.record_count to /health.
-    The field is minimal (a count only) and does not expose operational detail,
+    Phase 3 (REQ-P0-P3-004) added canary.trigger_count_24h to /health.
+    Both fields are minimal counts that do not expose operational detail,
     consistent with DEC-HEALTH-002's "public liveness probe" intent.
     """
     _reset_orchestrator_stats()
@@ -149,13 +150,16 @@ def test_health_returns_only_liveness_fields(tmp_path):
     assert resp.status_code == 200
 
     data = resp.json()
-    assert set(data.keys()) == {"status", "poller_healthy", "threat_intel"}, (
-        f"Expected exactly {{status, poller_healthy, threat_intel}}, got keys: {set(data.keys())}"
+    assert set(data.keys()) == {"status", "poller_healthy", "threat_intel", "canary"}, (
+        f"Expected exactly {{status, poller_healthy, threat_intel, canary}}, "
+        f"got keys: {set(data.keys())}"
     )
     assert data["status"] == "ok"
     assert isinstance(data["poller_healthy"], bool)
     assert "record_count" in data["threat_intel"]
     assert isinstance(data["threat_intel"]["record_count"], int)
+    assert "trigger_count_24h" in data["canary"]
+    assert isinstance(data["canary"]["trigger_count_24h"], int)
 
     conn.close()
 


### PR DESCRIPTION
## Scope

DNS + HTTP canary tokens: attacker-facing traps that file alerts through the existing clusterer/triage pipeline.

- `POST /canary/spawn` (auth-gated) — 201 with token + trap URL/hostname
- `GET /canary/hit/{token}` (public, attacker won't authenticate) — records alert row with `source='canary'`, increments `trigger_count`
- New SQLite table `canary_tokens` (idempotent `CREATE TABLE IF NOT EXISTS`, `CHECK(type IN ('dns','http'))`)
- `/health` gains `canary.trigger_count_24h` alongside `threat_intel.record_count` (from #35)

### Files
- `agent/canary.py` (new, 408 LOC) — spawn/hit/sanitize/CRUD. `DEC-CANARY-001` (128-bit entropy via `secrets.token_urlsafe(16)`), `DEC-CANARY-002` (shared alert row), `DEC-CANARY-003` (reuse clusterer + triage pipeline)
- `agent/main.py` — two new routes + health field
- `agent/models.py` — `canary_tokens` table + CRUD helpers
- `agent/config.py` — `CANARY_BASE_URL`, `CANARY_BASE_HOSTNAME`
- `tests/test_canary.py` (new, 12 tests), `tests/test_health.py` (updated exact-keys assertion)
- `.env.example` — documents new env vars

## Acceptance Criterion (REQ-P0-P3-004) — live evidence

> Canary trap hit → alert row with `source='canary'` → enters the shared clusterer + triage pipeline.

Verified end-to-end:
- Two live hits recorded two `source='canary'` alert rows
- After 5-min clustering window, cluster row: `1ec232e05912efbe | 127.0.0.1 | rule_id=0 | source=canary` with both alerts' `cluster_id` linked
- `/health` returned `{"status":"ok","poller_healthy":true,"threat_intel":{"record_count":0},"canary":{"trigger_count_24h":2}}`
- Auth matrix: 401 without bearer, 201 with valid, 422 on invalid type
- Security: all SQL parameterized; attacker User-Agent with XSS payload stored as literal string; no DB damage

## Tests

**161 passed, 1 skipped, 0 failed** (unchanged pre-existing PyYAML skip). Tool count still 7 (canary adds no orchestrator tool).

Full tester report (AUTOVERIFY: CLEAN): `.worktrees/feature-phase3-canary/tmp/verification-issue-34.md`

## @decision annotations

`agent/canary.py` lines 23, 32, 43 — `DEC-CANARY-001`, `DEC-CANARY-002`, `DEC-CANARY-003`. Sacred Practice #7 satisfied.

## Plan impact

Phase 3 is mid-phase (#33 and #36 still open). MASTER_PLAN.md is **not** updated by this merge per Sacred Practice #9 — phase-boundary update lands via `docs/plan-phase-3-complete` after the final Wave A issue + regression gate close.

Closes #34