### PR TITLE
docs(master-plan): mark Phase 3 completed; flip + add DEC entries

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -440,8 +440,10 @@ shaferhund/
 
 ## Phase 3: Immune System (2–3 weeks after Phase 2.5)
 
-**Status:** planned
+**Status:** completed
 **Timebox:** 2–3 weeks
+**Landed:** 2026-04-24 across PRs #37, #38, #39 (all squash-merged from `feature/phase3-*` branches; final commit `4e01640`)
+**Verified:** 2026-04-24 via Phase 3 zero-regression gate (issue #36): 180 passed / 1 skipped / 0 failed; `/health` integrates `{threat_intel, canary, posture}` keys cleanly; DB migration Phase 2.5 → Phase 3 idempotent; compose.yaml integrates `redteam-target` for 5 services total.
 
 ### Intent
 
@@ -605,14 +607,19 @@ shaferhund/
 
 | ID | Title | Status |
 |----|-------|--------|
-| DEC-REDTEAM-001 | External scheduled ART harness (not Claude-driven) | planned |
-| DEC-POSTURE-001 | Posture score = ART pass rate (deployed-rule coverage over total tests) | planned |
-| DEC-CANARY-001 | DNS + HTTP canary tokens only; service honeypots deferred to Phase 4 | planned |
-| DEC-THREATINTEL-001 | URLhaus only; STIX/TAXII federation deferred | planned |
-| DEC-ORCH-004 | `check_threat_intel` added via direct TOOLS patch (no dynamic registration refactor) | planned |
-| DEC-REDTEAM-002 | Declarative `atomic_tests.yaml`; no full ART auto-discovery | planned |
-| DEC-CANARY-002 | Canary events enter via existing `_persist_and_enqueue`; `source='canary'` | planned |
-| DEC-POSTURE-002 | Phase 3 P0 ships even if Phase 2.5 Sigma slips; YARA-biased score acceptable as interim | planned |
+| DEC-REDTEAM-001 | External scheduled ART harness (not Claude-driven) | accepted |
+| DEC-POSTURE-001 | Posture score = ART pass rate (deployed-rule coverage over total tests) | accepted |
+| DEC-CANARY-001 | DNS + HTTP canary tokens only; service honeypots deferred to Phase 4 | accepted |
+| DEC-THREATINTEL-001 | URLhaus only; STIX/TAXII federation deferred | accepted |
+| DEC-ORCH-004 | `check_threat_intel` added via direct TOOLS patch (no dynamic registration refactor) | accepted |
+| DEC-REDTEAM-002 | Declarative `atomic_tests.yaml`; no full ART auto-discovery | accepted |
+| DEC-CANARY-002 | Canary events enter via existing `_persist_and_enqueue`; `source='canary'` | accepted |
+| DEC-POSTURE-002 | Phase 3 P0 ships even if Phase 2.5 Sigma slips; YARA-biased score acceptable as interim | accepted |
+| DEC-ORCH-005 | 7th orchestrator tool added via direct `TOOLS` list patch + `make_read_tool_handlers` closure factory + `_TOOL_DISPATCH` entry; validates the scaling pattern, dynamic-registration refactor remains a Phase 4 item (REQ-NOGO-P3-008). Annotated at `agent/orchestrator.py:84` and `agent/threat_intel.py:20` | accepted |
+| DEC-CANARY-003 | Canary spawn/hit split: `agent/canary.py` owns DB helpers and pure functions; HTTP wiring (`POST /canary/spawn`, `GET /canary/hit/{token}`) stays in `agent/main.py` next to other route handlers — keeps the canary module testable without TestClient overhead. Annotated at `agent/canary.py:43` | accepted |
+| DEC-REDTEAM-003 | `run_batch` accepts an injectable `executor` callable so unit tests can mock subprocess invocation without monkey-patching; real path uses `subprocess.run([... podman exec ...])`. Annotated in `agent/red_team.py` | accepted |
+| DEC-REDTEAM-004 | `POST /posture/run` inserts the `posture_runs` row synchronously before spawning the asyncio background task, so the caller receives a valid `run_id` immediately and avoids a poll-before-row race; SQLite WAL mode lets concurrent readers see the committed row before the task completes. Annotated at `agent/main.py:711` | accepted |
+| DEC-REDTEAM-005 | `redteam-target` container ships Wazuh agent installed but NOT enrolled at build time; enrollment is a runtime operator step (`agent-auth -m wazuh.manager` after first compose up), avoiding build-time secrets and matching Wazuh 4.x recommended workflow. Annotated in `compose.yaml` | accepted |
 
 ## TODOs
 - [ ] Convert `hund` to `ROADMAP.md` (map 25 domains to phases)


### PR DESCRIPTION
## Summary

Phase 3 (Immune System) is fully landed and verified. This PR is the phase-boundary documentation flip — no source code changes, only `MASTER_PLAN.md`.

**Shipped via three squash-merged PRs into main today (2026-04-24):**
- #37 (`1845260`) — `feat(#35): check_threat_intel orchestrator tool + URLhaus feed` (REQ-P0-P3-005)
- #38 (`7061da0`) — `feat(#34): canary tokens + /canary routes` (REQ-P0-P3-004)
- #39 (`4e01640`) — `feat(#33): ART harness + posture score + redteam-target container` (REQ-P0-P3-001/002/003)

**Regression gate (issue #36, REQ-P0-P3-007) closed via tester verification:**
- 180 passed / 1 skipped / 0 failed
- `/health` integrates `{threat_intel, canary, posture}` keys cleanly
- DB migration Phase 2.5 → Phase 3 idempotent (`init_db` adds 4 new tables: `posture_runs`, `posture_test_results`, `canary_tokens`, `threat_intel`)
- `compose.yaml` integrates `redteam-target` for 5 services total

## Changes to `MASTER_PLAN.md`

**Phase 3 status block:**
- `Status: planned` → `Status: completed`
- Added `Landed:` line referencing PRs #37/#38/#39 + final commit `4e01640`
- Added `Verified:` line summarizing regression gate evidence

**Phase 3 Decision Log — flipped 8 entries `planned` → `accepted`:**
DEC-REDTEAM-001, DEC-POSTURE-001, DEC-CANARY-001, DEC-THREATINTEL-001, DEC-ORCH-004, DEC-REDTEAM-002, DEC-CANARY-002, DEC-POSTURE-002.

**Phase 3 Decision Log — appended 5 new entries surfaced during implementation:**
- DEC-ORCH-005 (`accepted`) — 7th orchestrator tool added via direct `TOOLS` patch + closure factory; validates the scaling pattern, dynamic-registration refactor remains a Phase 4 item (REQ-NOGO-P3-008)
- DEC-CANARY-003 (`accepted`) — spawn/hit module split: `agent/canary.py` owns DB helpers + pure functions; HTTP routes stay in `agent/main.py`
- DEC-REDTEAM-003 (`accepted`) — `run_batch` accepts an injectable `executor` callable for testability without monkey-patching
- DEC-REDTEAM-004 (`accepted`) — `POST /posture/run` inserts `posture_runs` row synchronously before fire-and-forget task to avoid poll-before-row race
- DEC-REDTEAM-005 (`accepted`) — `redteam-target` ships Wazuh agent installed but NOT enrolled at build time; enrollment is a runtime operator step matching Wazuh 4.x recommended workflow

## Out of scope

No source code, test, compose, or schema changes. Only `MASTER_PLAN.md` is touched.

## Side note

`pyyaml` was added to `requirements.txt` as part of #39 (needed for `atomic_tests.yaml`), which incidentally fixed the long-standing `test_write_sigma_rule_persists_valid` failure that had been on the books since Phase 2. Not a Phase 3 deliverable, but worth noting.

## Test plan

- [x] `MASTER_PLAN.md` diff is focused — 16 insertions / 9 deletions, all inside the Phase 3 section
- [x] No edits outside Phase 3 status block + Phase 3 Decision Log
- [x] All Phase 3 DEC IDs cross-checked against `@decision` annotations in source (`agent/red_team.py`, `agent/canary.py`, `agent/threat_intel.py`, `agent/orchestrator.py`, `agent/main.py`, `compose.yaml`)
- [ ] Guardian agent merges after orchestrator + user approval (do not self-merge)

Closes the Phase 3 boundary. Phase 4 scoping bullet remains in the existing `## TODOs` section as the next-up item.