### PR TITLE
feat(#43): weighted posture score (REQ-P0-P4-003)

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -342,6 +342,14 @@ async def health() -> JSONResponse:
     posture_row = get_latest_posture_run(_db) if _db is not None else None
     posture_last_score = float(posture_row["score"]) if posture_row is not None else None
     posture_last_run_at = posture_row["started_at"] if posture_row is not None else None
+    # Phase 4 (REQ-P0-P4-003): weighted_score — guard against Phase 3 DBs that
+    # predate the column (IndexError on sqlite3.Row key access).
+    try:
+        posture_last_weighted_score = (
+            float(posture_row["weighted_score"]) if posture_row is not None else None
+        )
+    except (IndexError, KeyError):
+        posture_last_weighted_score = None
     return JSONResponse({
         "status": "ok",
         "poller_healthy": _poller_healthy,
@@ -354,6 +362,7 @@ async def health() -> JSONResponse:
         "posture": {
             "last_score": posture_last_score,
             "last_run_at": posture_last_run_at,
+            "last_weighted_score": posture_last_weighted_score,
         },
     })
 

--- a/agent/models.py
+++ b/agent/models.py
@@ -10,6 +10,24 @@ Phase 2 additions: multi-source alert columns on `alerts` table
 (added via idempotent ALTER TABLE in init_db) and a new `deploy_events`
 table for the policy-gated auto-deploy audit trail.
 
+Phase 4 additions: weighted_score column on `posture_runs` and weight
+column on `posture_test_results`, both added via the idempotent
+_POSTURE_RUNS_PHASE4_COLUMNS pattern (DEC-SCHEMA-002). New helper
+compute_posture_weighted_score_for_run() computes the weighted average.
+
+@decision DEC-POSTURE-003
+@title Weighted posture score — declarative YAML weights, additive alongside flat score
+@status accepted
+@rationale The flat score (passes / total_tests) treats all MITRE techniques equally.
+           Phase 4 adds a parallel weighted score (sum(weight * passed) / sum(weight))
+           that reflects operator-assigned criticality from atomic_tests.yaml.
+           Both scores persist on posture_runs and expose on /health so Phase 3
+           callers are fully backwards-compatible. Weights are declared in YAML
+           (not judged by Claude at runtime) for determinism: the same test set
+           produces the same weighted score every run regardless of model version,
+           token availability, or hourly budget. Claude-judged adaptive weights
+           are a future enhancement (saves an LLM call per scoring run here).
+
 @decision DEC-CLUSTER-001
 @title In-memory clusterer with SQLite persistence
 @status accepted
@@ -264,6 +282,27 @@ CREATE INDEX IF NOT EXISTS idx_ptr_fired_at ON posture_test_results(fired_at);
 """
 
 
+# ---------------------------------------------------------------------------
+# Phase 4 schema additions — weighted posture score (REQ-P0-P4-003)
+# ---------------------------------------------------------------------------
+#
+# Both columns are added idempotently via PRAGMA table_info() gating
+# (DEC-SCHEMA-002) so a Phase 3 DB upgrades in place without data loss.
+#
+# posture_runs.weighted_score  — sum(weight * passed) / sum(weight), 0.0–1.0.
+#   DEFAULT 0.0 so existing rows remain valid after the ALTER TABLE.
+#
+# posture_test_results.weight  — per-test importance weight from atomic_tests.yaml.
+#   DEFAULT 1 so existing rows contribute equally until re-scored with real weights.
+_POSTURE_RUNS_PHASE4_COLUMNS: list[tuple[str, str]] = [
+    ("weighted_score", "REAL NOT NULL DEFAULT 0.0"),
+]
+
+_POSTURE_TEST_RESULTS_PHASE4_COLUMNS: list[tuple[str, str]] = [
+    ("weight", "INTEGER NOT NULL DEFAULT 1"),
+]
+
+
 def init_db(db_path: str) -> sqlite3.Connection:
     """Open (or create) the SQLite database and apply schema.
 
@@ -332,6 +371,30 @@ def init_db(db_path: str) -> sqlite3.Connection:
 
     # posture_test_results table (Phase 3, REQ-P0-P3-003) — idempotent.
     conn.executescript(_POSTURE_TEST_RESULTS_SQL)
+
+    # Phase 4: weighted_score column on posture_runs (REQ-P0-P4-003).
+    existing_posture_run_cols = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(posture_runs)").fetchall()
+    }
+    for col_name, col_def in _POSTURE_RUNS_PHASE4_COLUMNS:
+        if col_name not in existing_posture_run_cols:
+            conn.execute(
+                f"ALTER TABLE posture_runs ADD COLUMN {col_name} {col_def}"
+            )
+            log.info("posture_runs table: added column %s", col_name)
+
+    # Phase 4: weight column on posture_test_results (REQ-P0-P4-003).
+    existing_posture_tr_cols = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(posture_test_results)").fetchall()
+    }
+    for col_name, col_def in _POSTURE_TEST_RESULTS_PHASE4_COLUMNS:
+        if col_name not in existing_posture_tr_cols:
+            conn.execute(
+                f"ALTER TABLE posture_test_results ADD COLUMN {col_name} {col_def}"
+            )
+            log.info("posture_test_results table: added column %s", col_name)
 
     conn.commit()
     log.info("Database initialised at %s", db_path)
@@ -1085,30 +1148,36 @@ def update_posture_run(
     passes: int,
     score: float,
     status: str,
+    weighted_score: float = 0.0,
 ) -> None:
     """Update a posture_runs row with final results.
 
     Called after run_batch() completes (successfully or with failures).
+    Phase 4 adds weighted_score (REQ-P0-P4-003) alongside the existing flat
+    score. The parameter defaults to 0.0 for backwards compatibility with any
+    Phase 3 callers that don't supply it.
 
     Args:
-        conn:        Open SQLite connection.
-        run_id:      The posture_runs.id to update.
-        finished_at: ISO8601 timestamp when the run completed.
-        passes:      Number of tests that scored as a pass.
-        score:       passes / total_tests (0.0–1.0).
-        status:      'complete' or 'failed'.
+        conn:           Open SQLite connection.
+        run_id:         The posture_runs.id to update.
+        finished_at:    ISO8601 timestamp when the run completed.
+        passes:         Number of tests that scored as a pass.
+        score:          passes / total_tests (flat, 0.0–1.0).
+        status:         'complete' or 'failed'.
+        weighted_score: sum(weight*passed)/sum(weight) (0.0–1.0). Default 0.0.
     """
     with get_cursor(conn) as cur:
         cur.execute(
             """
             UPDATE posture_runs
-               SET finished_at = ?,
-                   passes      = ?,
-                   score       = ?,
-                   status      = ?
+               SET finished_at    = ?,
+                   passes         = ?,
+                   score          = ?,
+                   weighted_score = ?,
+                   status         = ?
              WHERE id = ?
             """,
-            (finished_at, passes, score, status, run_id),
+            (finished_at, passes, score, weighted_score, status, run_id),
         )
 
 
@@ -1244,6 +1313,70 @@ def compute_posture_score_for_run(
     return {"run_id": run_id, "total_tests": total_tests, "passes": passes, "score": score}
 
 
+def compute_posture_weighted_score_for_run(
+    conn: sqlite3.Connection,
+    run_id: int,
+) -> float:
+    """Compute the weighted posture score for a completed run.
+
+    Weighted scoring rule (REQ-P0-P4-003, DEC-POSTURE-003):
+      weighted_score = SUM(ptr.weight * pass_flag) / SUM(ptr.weight)
+
+    where pass_flag=1 when the test's fired_at falls inside a cluster window
+    that has at least one deployed rule (same join condition as the flat score),
+    and pass_flag=0 otherwise.
+
+    The weight per test is stored in posture_test_results.weight at insert time
+    (from atomic_tests.yaml, default 1). The SQL aggregation is done entirely
+    in SQL to avoid pulling rowsets into Python (DEC-POSTURE-001 pattern).
+
+    Divide-by-zero guard: returns 0.0 when SUM(weight) == 0 (e.g. all tests
+    have weight=0, or no test_results rows exist for this run_id).
+
+    This function does NOT update posture_runs — the caller (run_batch via
+    compute_posture_score_for_run flow) controls persistence. Call
+    update_posture_run(..., weighted_score=...) after this returns.
+
+    Args:
+        conn:   Open SQLite connection.
+        run_id: The posture_runs.id to score.
+
+    Returns:
+        Float in [0.0, 1.0]. Returns 0.0 on divide-by-zero.
+    """
+    # SUM(weight * 1) for passing tests / SUM(weight) for all tests in run.
+    # A test passes when fired_at is inside a cluster window AND that cluster
+    # has a deployed rule. Tests with no matching cluster/rule contribute 0
+    # to the numerator but their weight still appears in the denominator.
+    row = conn.execute(
+        """
+        SELECT
+            SUM(ptr.weight)                       AS total_weight,
+            SUM(CASE
+                WHEN EXISTS (
+                    SELECT 1
+                      FROM clusters cl
+                      JOIN rules r ON r.cluster_id = cl.id AND r.deployed = 1
+                     WHERE ptr.fired_at >= cl.window_start
+                       AND ptr.fired_at <= cl.window_end
+                ) THEN ptr.weight
+                ELSE 0
+            END)                                  AS weighted_passes
+          FROM posture_test_results ptr
+         WHERE ptr.run_id = ?
+        """,
+        (run_id,),
+    ).fetchone()
+
+    if row is None:
+        return 0.0
+    total_weight = row["total_weight"] or 0
+    weighted_passes = row["weighted_passes"] or 0
+    if total_weight == 0:
+        return 0.0
+    return float(weighted_passes) / float(total_weight)
+
+
 # ---------------------------------------------------------------------------
 # Posture Test Results CRUD  (Phase 3 — REQ-P0-P3-003)
 # ---------------------------------------------------------------------------
@@ -1260,8 +1393,14 @@ def insert_posture_test_result(
     fired_at: str,
     exit_code: Optional[int] = None,
     output: Optional[str] = None,
+    weight: int = 1,
 ) -> int:
     """Insert a per-test result row and return its id.
+
+    Phase 4 (REQ-P0-P4-003): weight is now persisted on the row so that
+    compute_posture_weighted_score_for_run can aggregate directly in SQL
+    without re-joining to atomic_tests.yaml. Defaults to 1 for backwards
+    compatibility with Phase 3 callers that don't supply it.
 
     Args:
         conn:         Open SQLite connection.
@@ -1271,6 +1410,7 @@ def insert_posture_test_result(
         fired_at:     ISO8601 timestamp when the test command was launched.
         exit_code:    Shell exit code of the test command (None if not yet run).
         output:       Captured stdout/stderr (truncated to 4096 chars).
+        weight:       Importance weight from atomic_tests.yaml (default 1).
 
     Returns:
         The new row's INTEGER PRIMARY KEY.
@@ -1280,9 +1420,9 @@ def insert_posture_test_result(
         cur.execute(
             """
             INSERT INTO posture_test_results
-                (run_id, technique_id, test_name, fired_at, exit_code, output, passed)
-            VALUES (?, ?, ?, ?, ?, ?, 0)
+                (run_id, technique_id, test_name, fired_at, exit_code, output, passed, weight)
+            VALUES (?, ?, ?, ?, ?, ?, 0, ?)
             """,
-            (run_id, technique_id, test_name, fired_at, exit_code, safe_output),
+            (run_id, technique_id, test_name, fired_at, exit_code, safe_output, weight),
         )
         return cur.lastrowid

--- a/agent/red_team.py
+++ b/agent/red_team.py
@@ -61,6 +61,7 @@ import yaml
 
 from .models import (
     compute_posture_score_for_run,
+    compute_posture_weighted_score_for_run,
     insert_posture_run,
     insert_posture_test_result,
     update_posture_run,
@@ -89,6 +90,9 @@ def load_atomic_tests(path: str) -> list[dict]:
         test_name (str)              — human-readable label
         command_or_script_hint (str) — command executed via the target container
         expected_wazuh_rule_ids (list[int]) — optional, for scoring hints
+        weight (int)                 — importance weight for weighted posture
+                                       score (Phase 4, REQ-P0-P4-003).
+                                       Absent entries default to 1 in run_batch.
 
     Args:
         path: Filesystem path to the YAML file (absolute or relative to cwd).
@@ -210,11 +214,13 @@ def run_batch(
             # Strip YAML block-scalar trailing whitespace
             if isinstance(command, str):
                 command = command.strip()
+            # Phase 4: read per-test weight (default 1 if absent, REQ-P0-P4-003)
+            weight = int(test.get("weight", 1))
 
             fired_at = datetime.now(timezone.utc).isoformat()
             log.info(
-                "ART run %d: executing technique=%s name=%r",
-                run_id, technique_id, test_name,
+                "ART run %d: executing technique=%s name=%r weight=%d",
+                run_id, technique_id, test_name, weight,
             )
 
             try:
@@ -236,6 +242,7 @@ def run_batch(
                 fired_at=fired_at,
                 exit_code=exit_code,
                 output=output,
+                weight=weight,
             )
 
             log.info(
@@ -247,15 +254,23 @@ def run_batch(
         log.error("ART run %d: batch loop error: %s", run_id, exc, exc_info=True)
         overall_status = "failed"
 
-    # Compute score via SQL join (DEC-POSTURE-001)
+    # Compute flat score via SQL join (DEC-POSTURE-001)
     try:
         score_result = compute_posture_score_for_run(conn, run_id)
         passes = score_result["passes"]
         score = score_result["score"]
     except Exception as exc:
-        log.error("ART run %d: score computation failed: %s", run_id, exc)
+        log.error("ART run %d: flat score computation failed: %s", run_id, exc)
         passes = 0
         score = 0.0
+        overall_status = "failed"
+
+    # Compute weighted score (REQ-P0-P4-003, DEC-POSTURE-003)
+    try:
+        weighted_score = compute_posture_weighted_score_for_run(conn, run_id)
+    except Exception as exc:
+        log.error("ART run %d: weighted score computation failed: %s", run_id, exc)
+        weighted_score = 0.0
         overall_status = "failed"
 
     finished_at = datetime.now(timezone.utc).isoformat()
@@ -266,11 +281,12 @@ def run_batch(
         passes=passes,
         score=score,
         status=overall_status,
+        weighted_score=weighted_score,
     )
 
     log.info(
-        "Posture run %d complete: status=%s passes=%d/%d score=%.3f",
-        run_id, overall_status, passes, total_tests, score,
+        "Posture run %d complete: status=%s passes=%d/%d score=%.3f weighted_score=%.3f",
+        run_id, overall_status, passes, total_tests, score, weighted_score,
     )
     return run_id
 

--- a/atomic_tests.yaml
+++ b/atomic_tests.yaml
@@ -16,6 +16,11 @@
 #   test_name                 — human-readable label for this specific test
 #   command_or_script_hint    — the command or script fragment to execute
 #   expected_wazuh_rule_ids   — list of Wazuh rule IDs expected to fire (for scoring)
+#   weight                    — integer importance weight for weighted posture score
+#                               (optional; defaults to 1 if absent). Higher = more
+#                               critical technique. Used by Phase 4 weighted scoring
+#                               (REQ-P0-P4-003, DEC-POSTURE-003). T1486/ransomware
+#                               would get weight=3; T1087/discovery stays at 1.
 #
 # The command_or_script_hint is executed via:
 #   podman exec <redteam-target> /bin/bash -c "<command_or_script_hint>"
@@ -30,6 +35,7 @@ tests:
     expected_wazuh_rule_ids:
       - 5501
       - 5502
+    weight: 2
 
   - technique_id: "T1059.004"
     test_name: "Command and Scripting Interpreter: Unix Shell"
@@ -37,6 +43,7 @@ tests:
       /bin/sh -c 'id && whoami && uname -a'
     expected_wazuh_rule_ids:
       - 5501
+    weight: 2
 
   - technique_id: "T1053.003"
     test_name: "Scheduled Task/Job: Cron (list cron jobs)"
@@ -46,6 +53,7 @@ tests:
     expected_wazuh_rule_ids:
       - 5401
       - 5402
+    weight: 2
 
   - technique_id: "T1087.001"
     test_name: "Account Discovery: Local Account"
@@ -54,3 +62,4 @@ tests:
     expected_wazuh_rule_ids:
       - 5501
       - 5715
+    weight: 1

--- a/tests/fixtures/atomic_test_sample.yaml
+++ b/tests/fixtures/atomic_test_sample.yaml
@@ -1,6 +1,9 @@
 # Cached sample ART YAML for deterministic tests.
 # Shape mirrors atomic_tests.yaml — used by test_red_team_harness.py so tests
 # do not depend on the repo-root file (which may change in future phases).
+#
+# Phase 4 (REQ-P0-P4-003): weight field added. Mix of weights 1, 2, 3 to
+# exercise weighted-vs-flat divergence in test scenarios.
 
 tests:
   - technique_id: "T1059.003"
@@ -9,6 +12,7 @@ tests:
       echo 'ART T1059.003 test'
     expected_wazuh_rule_ids:
       - 5501
+    weight: 3
 
   - technique_id: "T1053.003"
     test_name: "Scheduled Task/Job: Cron (list cron jobs)"
@@ -16,6 +20,7 @@ tests:
       crontab -l 2>/dev/null || echo 'no crontab'
     expected_wazuh_rule_ids:
       - 5401
+    weight: 2
 
   - technique_id: "T1087.001"
     test_name: "Account Discovery: Local Account"
@@ -23,3 +28,4 @@ tests:
       cat /etc/passwd | cut -d: -f1 | head -5
     expected_wazuh_rule_ids:
       - 5715
+    weight: 1

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -136,11 +136,12 @@ def _make_config(max_calls: int = 5, wall_timeout: float = 10.0) -> SimpleNamesp
 
 
 def test_health_returns_only_liveness_fields(tmp_path):
-    """GET /health → exactly {status, poller_healthy, threat_intel, canary}, nothing else.
+    """GET /health → exactly {status, poller_healthy, threat_intel, canary, posture}.
 
     Phase 3 (REQ-P0-P3-005) added threat_intel.record_count to /health.
     Phase 3 (REQ-P0-P3-004) added canary.trigger_count_24h to /health.
     Phase 3 (REQ-P0-P3-001) added posture.last_score + posture.last_run_at to /health.
+    Phase 4 (REQ-P0-P4-003) adds posture.last_weighted_score to /health.
     All fields are minimal summary values that do not expose operational detail,
     consistent with DEC-HEALTH-002's "public liveness probe" intent.
     """
@@ -161,11 +162,17 @@ def test_health_returns_only_liveness_fields(tmp_path):
     assert isinstance(data["threat_intel"]["record_count"], int)
     assert "trigger_count_24h" in data["canary"]
     assert isinstance(data["canary"]["trigger_count_24h"], int)
-    assert "last_score" in data["posture"]
-    assert "last_run_at" in data["posture"]
-    # Fresh DB — no runs yet, both should be null
-    assert data["posture"]["last_score"] is None
-    assert data["posture"]["last_run_at"] is None
+
+    posture = data["posture"]
+    assert "last_score" in posture, "posture.last_score missing"
+    assert "last_run_at" in posture, "posture.last_run_at missing"
+    assert "last_weighted_score" in posture, (
+        "posture.last_weighted_score missing — Phase 4 REQ-P0-P4-003"
+    )
+    # Fresh DB — no runs yet, all three should be null
+    assert posture["last_score"] is None
+    assert posture["last_run_at"] is None
+    assert posture["last_weighted_score"] is None
 
     conn.close()
 

--- a/tests/test_posture_score.py
+++ b/tests/test_posture_score.py
@@ -1,20 +1,32 @@
 """
-Posture score computation tests — REQ-P0-P3-001, REQ-P0-P3-003.
+Posture score computation tests — REQ-P0-P3-001, REQ-P0-P3-003, REQ-P0-P4-003.
 
-Tests compute_posture_score_for_run() via synthetic DB fixtures covering:
+Phase 3 scenarios (unchanged):
   A. ART test at T, cluster window spans T, cluster has deployed=1 rule → pass=1
   B. ART test at T, no cluster exists → pass=0
   C. ART test at T, cluster exists but no deployed rule → pass=0
   Mixed: 3-test batch (A+B+C) → passes=1, total=3, score≈0.333
 
+Phase 4 weighted scoring scenarios (new):
+  W1. Single test weight=3, passes → flat=1.0, weighted=1.0
+  W2. A(weight=3, pass) + B(weight=1, fail) → flat=0.5, weighted=0.75
+  W3. A(weight=1, pass) + B(weight=3, fail) → flat=0.5, weighted=0.25
+  W4. All tests weight=0 → weighted=0.0, no crash (divide-by-zero guard)
+
 All tests use in-memory SQLite with real schema via init_db() and real
-SQL from compute_posture_score_for_run(). No mocks — the scoring SQL is
-the production code under test (DEC-POSTURE-001, Sacred Practice #5).
+SQL from compute_posture_score_for_run() / compute_posture_weighted_score_for_run().
+No mocks — the scoring SQL is the production code under test
+(DEC-POSTURE-001, DEC-POSTURE-003, Sacred Practice #5).
 
 @decision DEC-POSTURE-001
 @title Posture pass = cluster window overlap AND deployed rule — pure SQL join
 @status accepted
 @rationale See models.py compute_posture_score_for_run docstring.
+
+@decision DEC-POSTURE-003
+@title Weighted posture score — declarative YAML weights, additive alongside flat
+@status accepted
+@rationale See models.py module docstring.
 """
 
 import json
@@ -24,6 +36,7 @@ import pytest
 
 from agent.models import (
     compute_posture_score_for_run,
+    compute_posture_weighted_score_for_run,
     get_posture_run,
     init_db,
     insert_posture_run,
@@ -74,7 +87,7 @@ def _make_run(conn, n_tests: int, technique_ids: list[str]) -> int:
     return insert_posture_run(conn, started_at, technique_ids, n_tests)
 
 
-def _add_result(conn, run_id: int, technique_id: str, fired_at: str) -> int:
+def _add_result(conn, run_id: int, technique_id: str, fired_at: str, weight: int = 1) -> int:
     """Insert a posture_test_results row at the given fired_at timestamp."""
     return insert_posture_test_result(
         conn,
@@ -84,6 +97,7 @@ def _add_result(conn, run_id: int, technique_id: str, fired_at: str) -> int:
         fired_at=fired_at,
         exit_code=0,
         output="ok",
+        weight=weight,
     )
 
 
@@ -294,5 +308,207 @@ def test_compute_posture_score_updates_posture_runs_row():
     # Both tests fired inside the window with a deployed rule → both pass
     assert row["passes"] == 2, f"Expected passes=2, got {row['passes']}"
     assert abs(row["score"] - 1.0) < 1e-9
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 weighted scoring — REQ-P0-P4-003, DEC-POSTURE-003
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_single_pass_high_weight():
+    """W1: single test weight=3, passes → flat=1.0, weighted=1.0.
+
+    When all tests pass, weighted equals flat regardless of the weight values.
+    """
+    conn = init_db(":memory:")
+
+    now = datetime.now(timezone.utc)
+    fired_at = _iso(now)
+    window_start = _iso(now - timedelta(minutes=5))
+    window_end = _iso(now + timedelta(minutes=5))
+
+    _seed_cluster(conn, "cluster-w1", window_start, window_end)
+    _seed_rule(conn, "rule-w1", "cluster-w1", deployed=True)
+
+    run_id = _make_run(conn, 1, ["T1059.003"])
+    _add_result(conn, run_id, "T1059.003", fired_at, weight=3)
+
+    flat_result = compute_posture_score_for_run(conn, run_id)
+    weighted = compute_posture_weighted_score_for_run(conn, run_id)
+
+    assert abs(flat_result["score"] - 1.0) < 1e-9, f"Expected flat=1.0, got {flat_result['score']}"
+    assert abs(weighted - 1.0) < 1e-9, f"Expected weighted=1.0, got {weighted}"
+
+    conn.close()
+
+
+def test_weighted_heavy_pass_light_fail():
+    """W2: A(weight=3, pass) + B(weight=1, fail) → flat=0.5, weighted=0.75.
+
+    Weighted numerator = 3*1 + 1*0 = 3. Denominator = 3+1 = 4. Score = 0.75.
+    Flat: 1 pass / 2 tests = 0.5.
+    """
+    conn = init_db(":memory:")
+
+    now = datetime.now(timezone.utc)
+
+    # Cluster A (window covers fired_a): has deployed rule → A passes
+    a_start = _iso(now - timedelta(minutes=10))
+    a_end = _iso(now - timedelta(minutes=5))
+    _seed_cluster(conn, "cluster-w2a", a_start, a_end)
+    _seed_rule(conn, "rule-w2a", "cluster-w2a", deployed=True)
+
+    # No cluster for B → B fails
+    run_id = _make_run(conn, 2, ["T1059.003", "T1087.001"])
+    fired_a = _iso(now - timedelta(minutes=7))   # inside cluster-w2a
+    fired_b = _iso(now)                           # no cluster → fail
+
+    _add_result(conn, run_id, "T1059.003", fired_a, weight=3)
+    _add_result(conn, run_id, "T1087.001", fired_b, weight=1)
+
+    flat_result = compute_posture_score_for_run(conn, run_id)
+    weighted = compute_posture_weighted_score_for_run(conn, run_id)
+
+    assert flat_result["passes"] == 1
+    assert abs(flat_result["score"] - 0.5) < 1e-9, f"Expected flat=0.5, got {flat_result['score']}"
+    assert abs(weighted - 0.75) < 1e-9, f"Expected weighted=0.75, got {weighted}"
+
+    conn.close()
+
+
+def test_weighted_light_pass_heavy_fail():
+    """W3: A(weight=1, pass) + B(weight=3, fail) → flat=0.5, weighted=0.25.
+
+    Weighted numerator = 1*1 + 3*0 = 1. Denominator = 1+3 = 4. Score = 0.25.
+    Flat: 1 pass / 2 tests = 0.5.
+    """
+    conn = init_db(":memory:")
+
+    now = datetime.now(timezone.utc)
+
+    # Cluster A (window covers fired_a): has deployed rule → A passes
+    a_start = _iso(now - timedelta(minutes=10))
+    a_end = _iso(now - timedelta(minutes=5))
+    _seed_cluster(conn, "cluster-w3a", a_start, a_end)
+    _seed_rule(conn, "rule-w3a", "cluster-w3a", deployed=True)
+
+    run_id = _make_run(conn, 2, ["T1059.003", "T1087.001"])
+    fired_a = _iso(now - timedelta(minutes=7))   # inside cluster-w3a → pass
+    fired_b = _iso(now)                           # no cluster → fail
+
+    _add_result(conn, run_id, "T1059.003", fired_a, weight=1)
+    _add_result(conn, run_id, "T1087.001", fired_b, weight=3)
+
+    flat_result = compute_posture_score_for_run(conn, run_id)
+    weighted = compute_posture_weighted_score_for_run(conn, run_id)
+
+    assert flat_result["passes"] == 1
+    assert abs(flat_result["score"] - 0.5) < 1e-9, f"Expected flat=0.5, got {flat_result['score']}"
+    assert abs(weighted - 0.25) < 1e-9, f"Expected weighted=0.25, got {weighted}"
+
+    conn.close()
+
+
+def test_weighted_all_equal_weights_matches_flat():
+    """When all weights are equal, weighted score equals flat score."""
+    conn = init_db(":memory:")
+
+    now = datetime.now(timezone.utc)
+    window_start = _iso(now - timedelta(minutes=5))
+    window_end = _iso(now + timedelta(minutes=5))
+
+    _seed_cluster(conn, "cluster-weq", window_start, window_end)
+    _seed_rule(conn, "rule-weq", "cluster-weq", deployed=True)
+
+    # 3 tests, 2 pass (inside window), 1 no-cluster fail
+    run_id = _make_run(conn, 3, ["T1059.003", "T1053.003", "T1087.001"])
+    fired_in = _iso(now)
+    fired_out = _iso(now - timedelta(hours=1))  # before window → no cluster match
+
+    _add_result(conn, run_id, "T1059.003", fired_in, weight=2)
+    _add_result(conn, run_id, "T1053.003", fired_in, weight=2)
+    _add_result(conn, run_id, "T1087.001", fired_out, weight=2)
+
+    flat_result = compute_posture_score_for_run(conn, run_id)
+    weighted = compute_posture_weighted_score_for_run(conn, run_id)
+
+    # flat = 2/3, weighted = (2*2 + 2*2 + 2*0)/(2+2+2) = 4/6 = 2/3
+    expected = 2 / 3
+    assert abs(flat_result["score"] - expected) < 1e-9, (
+        f"flat={flat_result['score']}, expected {expected}"
+    )
+    assert abs(weighted - expected) < 1e-9, (
+        f"weighted={weighted}, expected {expected}"
+    )
+
+    conn.close()
+
+
+def test_weighted_zero_weight_divide_by_zero_guard():
+    """W4: all tests have weight=0 → weighted_score=0.0, no crash.
+
+    SUM(weight) == 0 is the divide-by-zero edge case. compute_posture_weighted_score_for_run
+    must return 0.0 without raising.
+    """
+    conn = init_db(":memory:")
+
+    now = datetime.now(timezone.utc)
+    window_start = _iso(now - timedelta(minutes=5))
+    window_end = _iso(now + timedelta(minutes=5))
+
+    _seed_cluster(conn, "cluster-w0", window_start, window_end)
+    _seed_rule(conn, "rule-w0", "cluster-w0", deployed=True)
+
+    run_id = _make_run(conn, 2, ["T1059.003", "T1087.001"])
+    fired_at = _iso(now)
+
+    _add_result(conn, run_id, "T1059.003", fired_at, weight=0)
+    _add_result(conn, run_id, "T1087.001", fired_at, weight=0)
+
+    weighted = compute_posture_weighted_score_for_run(conn, run_id)
+
+    assert weighted == 0.0, f"Expected 0.0 on all-zero weights, got {weighted}"
+
+    conn.close()
+
+
+def test_weighted_score_persisted_by_update_posture_run():
+    """update_posture_run persists weighted_score alongside flat score and passes."""
+    conn = init_db(":memory:")
+
+    now = datetime.now(timezone.utc)
+    window_start = _iso(now - timedelta(minutes=5))
+    window_end = _iso(now + timedelta(minutes=5))
+
+    _seed_cluster(conn, "cluster-persist-w", window_start, window_end)
+    _seed_rule(conn, "rule-persist-w", "cluster-persist-w", deployed=True)
+
+    run_id = _make_run(conn, 2, ["T1059.003", "T1087.001"])
+    fired_a = _iso(now)  # passes
+    fired_b = _iso(now - timedelta(hours=2))  # no cluster → fails
+
+    _add_result(conn, run_id, "T1059.003", fired_a, weight=3)
+    _add_result(conn, run_id, "T1087.001", fired_b, weight=1)
+
+    flat_result = compute_posture_score_for_run(conn, run_id)
+    weighted = compute_posture_weighted_score_for_run(conn, run_id)
+
+    update_posture_run(
+        conn,
+        run_id=run_id,
+        finished_at=_now_iso(),
+        passes=flat_result["passes"],
+        score=flat_result["score"],
+        status="complete",
+        weighted_score=weighted,
+    )
+
+    row = dict(get_posture_run(conn, run_id))
+    assert "weighted_score" in row, "weighted_score column missing from posture_runs row"
+    # flat=0.5, weighted=3/(3+1)=0.75
+    assert abs(row["score"] - 0.5) < 1e-9, f"flat score={row['score']}"
+    assert abs(row["weighted_score"] - 0.75) < 1e-9, f"weighted_score={row['weighted_score']}"
 
     conn.close()

--- a/tests/test_red_team_harness.py
+++ b/tests/test_red_team_harness.py
@@ -307,3 +307,76 @@ def test_posture_run_route_requires_auth(tmp_path):
         f"Expected 401 for unauthenticated /posture/run, got {resp.status_code}"
     )
     conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: run_batch with mixed weights → both scores on posture_runs row
+# ---------------------------------------------------------------------------
+
+def test_run_batch_weighted_score_persisted():
+    """run_batch with mixed-weight fixture: both score and weighted_score end up correct.
+
+    Fixture has 3 tests: T1059.003(weight=3), T1053.003(weight=2), T1087.001(weight=1).
+    The fake executor always succeeds (exit_code=0), but no clusters or rules exist
+    in the DB, so the SQL scoring join finds no deployed rules → all tests fail scoring.
+
+    Expected: passes=0, score=0.0, weighted_score=0.0.
+
+    This verifies that run_batch writes weighted_score to the posture_runs row
+    (not just score), and that the column exists after Phase 4 migration. The
+    divergence scenarios are covered by test_posture_score.py W2/W3.
+    """
+    conn = init_db(":memory:")
+    tests = [
+        {"technique_id": "T1059.003", "test_name": "test-a",
+         "command_or_script_hint": "echo a", "weight": 3},
+        {"technique_id": "T1053.003", "test_name": "test-b",
+         "command_or_script_hint": "echo b", "weight": 2},
+        {"technique_id": "T1087.001", "test_name": "test-c",
+         "command_or_script_hint": "echo c", "weight": 1},
+    ]
+    executor = _make_fake_executor(exit_code=0, output="ok")
+
+    run_id = run_batch(conn, tests, "test-target", executor=executor)
+
+    row = dict(conn.execute(
+        "SELECT * FROM posture_runs WHERE id = ?", (run_id,)
+    ).fetchone())
+
+    # No clusters → scoring join returns 0 passes for both metrics
+    assert row["score"] == 0.0, f"Expected flat score=0.0, got {row['score']}"
+    assert "weighted_score" in row, "weighted_score column missing from posture_runs row"
+    assert row["weighted_score"] == 0.0, f"Expected weighted_score=0.0, got {row['weighted_score']}"
+
+    # Verify per-test weights were stored in posture_test_results
+    result_rows = conn.execute(
+        "SELECT technique_id, weight FROM posture_test_results WHERE run_id = ? ORDER BY id",
+        (run_id,),
+    ).fetchall()
+    weights_by_tech = {r["technique_id"]: r["weight"] for r in result_rows}
+    assert weights_by_tech.get("T1059.003") == 3, f"Expected weight=3, got {weights_by_tech}"
+    assert weights_by_tech.get("T1053.003") == 2, f"Expected weight=2, got {weights_by_tech}"
+    assert weights_by_tech.get("T1087.001") == 1, f"Expected weight=1, got {weights_by_tech}"
+
+    conn.close()
+
+
+def test_run_batch_weight_defaults_to_1_when_absent():
+    """run_batch defaults weight=1 when a test dict has no 'weight' key."""
+    conn = init_db(":memory:")
+    tests = [
+        {"technique_id": "T1059.003", "test_name": "no-weight",
+         "command_or_script_hint": "echo x"},  # no weight key
+    ]
+    executor = _make_fake_executor(exit_code=0, output="ok")
+
+    run_id = run_batch(conn, tests, "test-target", executor=executor)
+
+    result_rows = conn.execute(
+        "SELECT weight FROM posture_test_results WHERE run_id = ?", (run_id,)
+    ).fetchall()
+    assert len(result_rows) == 1
+    assert result_rows[0]["weight"] == 1, (
+        f"Expected default weight=1, got {result_rows[0]['weight']}"
+    )
+    conn.close()


### PR DESCRIPTION
## Scope

Implements **REQ-P0-P4-003: Weighted posture score**. Each atomic test in `atomic_tests.yaml` now carries a `weight` (default 1). The posture run computes a weighted average of the pass/fail outcomes, exposed as `last_weighted_score` on `/health`.

## Acceptance criteria

- [x] Per-test `weight` field in `atomic_tests.yaml` (default 1, additive, backwards compatible)
- [x] New `weighted_score REAL` column on `posture_runs` via idempotent `ALTER TABLE` (DEC-SCHEMA-002)
- [x] New `weight INTEGER DEFAULT 1` column on `posture_test_results`
- [x] `compute_posture_weighted_score_for_run(run_id)` SQL helper (weighted average, same join shape as flat score)
- [x] `/health` posture block extended with `last_weighted_score` — Phase 3 keys preserved
- [x] DEC-POSTURE-003 annotation in `agent/models.py:18-29` documenting the YAML-over-LLM choice for weight source
- [x] Phase 3 → Phase 4 DB migration idempotent; old rows get `weighted_score=0.0` default
- [x] TOOLS count unchanged at 7

## Verification

**AUTOVERIFY: CLEAN** (full report: `tmp/verification-issue-43.md`)

- 196 passed / 1 skipped / 0 failed (implementer); 194 / 2 / 0 (tester)
- Weighted math exact across 3 scenarios: A(w=3,pass)+B(w=1,fail)=0.75 | flipped weights=0.25 | all-zero=0.0 (divide-by-zero guard)
- `/health` non-null path verified via TestClient with seeded completed run: `posture.last_weighted_score=0.75`
- All Phase 3 scoring scenarios (`test_posture_score.py`) pass unchanged

## Note

Negative weights (e.g. `weight=-1` paired with positive) can collapse SUM=0 and the divide-by-zero guard silently returns `0.0`. Documented behavior; not a blocker for this phase. Future hardening: reject non-positive weights at YAML load time. Captured for a later wave.

Closes #43
