### PR TITLE
feat(#45): recommend_attack 8th orchestrator tool + approval flow (REQ-P0-P4-001/002)

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -101,11 +101,15 @@ from . import canary as _canary
 from .canary import spawn_canary, record_hit, count_canary_triggers_since
 from . import red_team as _red_team
 from .models import (
+    count_pending_attack_recommendations,
+    get_attack_recommendation,
     get_latest_posture_run,
     get_open_slo_breach,
     insert_posture_run,
+    list_pending_attack_recommendations,
 )
 from . import slo as _slo
+from . import recommendations as _recommendations
 
 log = logging.getLogger(__name__)
 
@@ -376,6 +380,11 @@ async def health() -> JSONResponse:
     slo_breach_open = (
         get_open_slo_breach(_db) is not None if _db is not None else False
     )
+    # Phase 4 Wave B (REQ-P0-P4-001): pending_count only — no row detail.
+    # Public, minimal: operators poll /recommendations for the full list.
+    pending_recs = (
+        count_pending_attack_recommendations(_db) if _db is not None else 0
+    )
     return JSONResponse({
         "status": "ok",
         "poller_healthy": _poller_healthy,
@@ -390,6 +399,9 @@ async def health() -> JSONResponse:
             "last_run_at": posture_last_run_at,
             "last_weighted_score": posture_last_weighted_score,
             "slo_breach_open": slo_breach_open,
+        },
+        "recommendations": {
+            "pending_count": pending_recs,
         },
     })
 
@@ -793,6 +805,116 @@ async def posture_run() -> JSONResponse:
     asyncio.create_task(_run_in_background(), name=f"posture-run-{run_id}")
     log.info("POST /posture/run: started run_id=%d (%d tests)", run_id, len(tests))
     return JSONResponse({"run_id": run_id, "status": "running"})
+
+
+# ---------------------------------------------------------------------------
+# Attack recommendation routes (Phase 4 Wave B, REQ-P0-P4-001/002)
+# ---------------------------------------------------------------------------
+
+
+@app.get(
+    "/recommendations",
+    dependencies=[Depends(_require_auth)],
+)
+async def list_recommendations() -> JSONResponse:
+    """List pending attack recommendations for operator review.
+
+    Auth-gated — same SHAFERHUND_TOKEN bearer scheme as all write routes.
+    Returns only status='pending' rows. Each row includes a 'destructive'
+    boolean derived from the code-resident DESTRUCTIVE_TECHNIQUES frozenset
+    (DEC-RECOMMEND-002) so operators can see at a glance which recommendations
+    require force=true to execute.
+
+    Returns:
+        JSON array of recommendation objects, newest first (max 50).
+        Empty array when no pending recommendations exist.
+    """
+    if _db is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    rows = list_pending_attack_recommendations(_db, limit=50)
+    result = []
+    for row in rows:
+        rec = dict(row)
+        rec["destructive"] = _recommendations.is_destructive(rec.get("technique_id", ""))
+        result.append(rec)
+
+    return JSONResponse(result)
+
+
+@app.post(
+    "/recommendations/{recommendation_id}/execute",
+    dependencies=[Depends(_require_auth)],
+)
+async def execute_recommendation_route(
+    recommendation_id: int,
+    request: Request,
+) -> JSONResponse:
+    """Execute an approved attack recommendation via the ART harness.
+
+    Auth-gated — this endpoint execs commands inside a container. Auth is
+    non-negotiable (DEC-RECOMMEND-001; same rationale as /posture/run).
+
+    Request body (optional JSON):
+        force (bool): If true, bypass the destructive technique check.
+                      Default: false. This is the ONLY runtime bypass path
+                      for destructive techniques — there is no env-var
+                      equivalent (DEC-RECOMMEND-002).
+
+    Returns:
+        200  {"recommendation_id": id, "run_id": int, "status": "executed"}
+        400  {"detail": "..."}  — not pending, or destructive without force
+        404  {"detail": "..."}  — recommendation not found
+
+    The actual run_batch call runs synchronously (via asyncio.create_task in
+    a thread) for the same reason as /posture/run: subprocess calls would
+    block the event loop. The run_id is returned immediately; the posture_runs
+    row is updated to 'complete' or 'failed' when the batch finishes.
+
+    @decision DEC-RECOMMEND-001
+    @title Operator HTTP POST is the sole execution trigger
+    @status accepted
+    @rationale See recommendations.py module docstring.
+    """
+    if _db is None or _settings is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    # Parse optional request body for force flag
+    force = False
+    try:
+        body = await request.json()
+        force = bool(body.get("force", False))
+    except Exception:
+        pass  # Empty or non-JSON body → force stays False
+
+    result = _recommendations.execute_recommendation(
+        conn=_db,
+        recommendation_id=recommendation_id,
+        force=force,
+        target_container=_settings.redteam_target_container,
+        executor=None,  # use default podman exec in production
+    )
+
+    exec_status = result.get("status")
+
+    if exec_status == "not_found":
+        raise HTTPException(status_code=404, detail=result["error"])
+
+    if exec_status in ("rejected", "already_executed"):
+        raise HTTPException(status_code=400, detail=result["error"])
+
+    # status == "executed"
+    log.info(
+        "POST /recommendations/%d/execute: run_id=%s force=%s",
+        recommendation_id,
+        result.get("run_id"),
+        force,
+    )
+    return JSONResponse({
+        "recommendation_id": recommendation_id,
+        "run_id": result["run_id"],
+        "status": "executed",
+    })
 
 
 async def _canary_enqueue(alert_obj) -> None:

--- a/agent/models.py
+++ b/agent/models.py
@@ -15,6 +15,13 @@ column on `posture_test_results`, both added via the idempotent
 _POSTURE_RUNS_PHASE4_COLUMNS pattern (DEC-SCHEMA-002). New helper
 compute_posture_weighted_score_for_run() computes the weighted average.
 
+Phase 4 Wave B additions: attack_recommendations table (DEC-RECOMMEND-001,
+REQ-P0-P4-001/002). Created with CREATE TABLE IF NOT EXISTS — idempotent on
+all prior Phase DBs (DEC-SCHEMA-002). CRUD helpers:
+  insert_attack_recommendation, get_attack_recommendation,
+  list_pending_attack_recommendations, mark_attack_recommendation_executed,
+  count_pending_attack_recommendations.
+
 @decision DEC-POSTURE-003
 @title Weighted posture score — declarative YAML weights, additive alongside flat score
 @status accepted
@@ -344,6 +351,41 @@ CREATE INDEX IF NOT EXISTS idx_slo_breaches_resolved_at
 """
 
 
+# ---------------------------------------------------------------------------
+# Phase 4 Wave B schema additions — attack_recommendations table
+# (REQ-P0-P4-001, REQ-P0-P4-002)
+# ---------------------------------------------------------------------------
+#
+# attack_recommendations: one row per Claude-generated recommendation.
+# Claude writes rows via the recommend_attack tool handler (status='pending').
+# Operator approval flows through POST /recommendations/{id}/execute which
+# calls agent.recommendations.execute_recommendation() and transitions to
+# status='executed'. Rejection (operator declines) sets status='rejected'.
+# Expiration (future: TTL sweep) sets status='expired'.
+#
+# DEC-RECOMMEND-001: Claude's handler ONLY writes status='pending'. Execution
+#   is a separate operator-gated HTTP action, never triggered automatically.
+# DEC-SCHEMA-002: CREATE TABLE IF NOT EXISTS — idempotent for all prior DBs.
+_ATTACK_RECOMMENDATIONS_SQL = """
+CREATE TABLE IF NOT EXISTS attack_recommendations (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    cluster_id      TEXT,
+    technique_id    TEXT    NOT NULL,
+    reason          TEXT    NOT NULL,
+    severity        TEXT    NOT NULL CHECK(severity IN ('Low','Medium','High','Critical')),
+    status          TEXT    NOT NULL DEFAULT 'pending'
+                            CHECK(status IN ('pending','executed','rejected','expired')),
+    created_at      TEXT    NOT NULL,
+    executed_at     TEXT,
+    posture_run_id  INTEGER REFERENCES posture_runs(id),
+    notes           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_attack_recommendations_status
+    ON attack_recommendations(status);
+"""
+
+
 def init_db(db_path: str) -> sqlite3.Connection:
     """Open (or create) the SQLite database and apply schema.
 
@@ -439,6 +481,9 @@ def init_db(db_path: str) -> sqlite3.Connection:
 
     # Phase 4: slo_breaches table (REQ-P0-P4-005) — idempotent via IF NOT EXISTS.
     conn.executescript(_SLO_BREACHES_SQL)
+
+    # Phase 4 Wave B: attack_recommendations table (REQ-P0-P4-001/002) — idempotent.
+    conn.executescript(_ATTACK_RECOMMENDATIONS_SQL)
 
     conn.commit()
     log.info("Database initialised at %s", db_path)
@@ -1571,3 +1616,141 @@ def resolve_slo_breach(
             "UPDATE slo_breaches SET resolved_at = ? WHERE id = ?",
             (resolved_at, breach_id),
         )
+
+
+# ---------------------------------------------------------------------------
+# Attack Recommendations CRUD  (Phase 4 Wave B — REQ-P0-P4-001/002)
+# ---------------------------------------------------------------------------
+
+def insert_attack_recommendation(
+    conn: sqlite3.Connection,
+    technique_id: str,
+    reason: str,
+    severity: str,
+    cluster_id: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> int:
+    """Insert a new attack_recommendations row with status='pending'.
+
+    Called by the recommend_attack tool handler in orchestrator.py. The row
+    represents Claude's suggestion to run an ART technique — it is NOT executed
+    automatically (DEC-RECOMMEND-001). Execution requires operator approval via
+    POST /recommendations/{id}/execute.
+
+    Args:
+        conn:         Open SQLite connection.
+        technique_id: MITRE ATT&CK technique ID (e.g. 'T1059.003').
+        reason:       Claude's rationale (sanitized by the handler before insert).
+        severity:     One of 'Low', 'Medium', 'High', 'Critical'.
+        cluster_id:   Optional cluster being triaged when the recommendation was made.
+                      Soft reference to clusters.id (TEXT). No FK constraint —
+                      the link is informational; tests and standalone handler calls
+                      may supply a cluster_id that does not exist in clusters.
+        notes:        Optional operator notes.
+
+    Returns:
+        The INTEGER PRIMARY KEY of the new row.
+    """
+    created_at = datetime.now(timezone.utc).isoformat()
+    with get_cursor(conn) as cur:
+        cur.execute(
+            """
+            INSERT INTO attack_recommendations
+                (cluster_id, technique_id, reason, severity, status, created_at, notes)
+            VALUES (?, ?, ?, ?, 'pending', ?, ?)
+            """,
+            (cluster_id, technique_id, reason, severity, created_at, notes),
+        )
+        return cur.lastrowid
+
+
+def get_attack_recommendation(
+    conn: sqlite3.Connection,
+    recommendation_id: int,
+) -> Optional[sqlite3.Row]:
+    """Return a single attack_recommendations row by id, or None.
+
+    Args:
+        conn:              Open SQLite connection.
+        recommendation_id: The attack_recommendations.id to fetch.
+
+    Returns:
+        sqlite3.Row or None if not found.
+    """
+    return conn.execute(
+        "SELECT * FROM attack_recommendations WHERE id = ?",
+        (recommendation_id,),
+    ).fetchone()
+
+
+def list_pending_attack_recommendations(
+    conn: sqlite3.Connection,
+    limit: int = 50,
+) -> list[sqlite3.Row]:
+    """Return attack_recommendations rows with status='pending', newest first.
+
+    Used by GET /recommendations to surface pending items for operator review.
+
+    Args:
+        conn:  Open SQLite connection.
+        limit: Maximum rows to return (default 50).
+
+    Returns:
+        List of sqlite3.Row objects ordered by created_at DESC.
+    """
+    return conn.execute(
+        """
+        SELECT * FROM attack_recommendations
+        WHERE status = 'pending'
+        ORDER BY created_at DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+
+
+def mark_attack_recommendation_executed(
+    conn: sqlite3.Connection,
+    recommendation_id: int,
+    posture_run_id: Optional[int] = None,
+) -> None:
+    """Flip a recommendation row from 'pending' to 'executed'.
+
+    Sets executed_at to now(UTC) and links posture_run_id so the operator can
+    correlate the recommendation with the resulting posture run.
+
+    Args:
+        conn:              Open SQLite connection.
+        recommendation_id: The attack_recommendations.id to update.
+        posture_run_id:    The posture_runs.id created by execute_recommendation().
+    """
+    executed_at = datetime.now(timezone.utc).isoformat()
+    with get_cursor(conn) as cur:
+        cur.execute(
+            """
+            UPDATE attack_recommendations
+               SET status         = 'executed',
+                   executed_at    = ?,
+                   posture_run_id = ?
+             WHERE id = ?
+            """,
+            (executed_at, posture_run_id, recommendation_id),
+        )
+
+
+def count_pending_attack_recommendations(conn: sqlite3.Connection) -> int:
+    """Return the count of attack_recommendations rows with status='pending'.
+
+    Used by /health to expose recommendations.pending_count without returning
+    full rows (DEC-HEALTH-002 — public, minimal).
+
+    Args:
+        conn: Open SQLite connection.
+
+    Returns:
+        Integer count, 0 when no pending rows exist.
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) FROM attack_recommendations WHERE status = 'pending'"
+    ).fetchone()
+    return int(row[0]) if row else 0

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -142,6 +142,7 @@ from .models import (
     get_cluster_with_alerts,
     get_recent_deploys,
     get_rules_for_cluster,
+    insert_attack_recommendation,
     insert_deploy_event,
     insert_rule,
     mark_rule_deployed,
@@ -1107,6 +1108,124 @@ register_tool(
     allows_no_conn=True,  # produces TriageResult even without DB (no-DB unit test path)
     kind="write",
 )
+
+
+# ---------------------------------------------------------------------------
+# 8th tool handler — recommend_attack (REQ-P0-P4-001, DEC-RECOMMEND-001)
+# ---------------------------------------------------------------------------
+
+
+def _handle_recommend_attack(
+    tool_input: dict,
+    conn: sqlite3.Connection,
+    cluster_id: str = "",
+) -> str:
+    """Record an ART technique recommendation for operator review.
+
+    This handler ONLY writes a status='pending' row to attack_recommendations.
+    It does NOT execute any technique. Execution requires an explicit operator
+    HTTP POST to /recommendations/{id}/execute (DEC-RECOMMEND-001).
+
+    The reason field is sanitized via sanitize_alert_field() before storage
+    because Claude's recommendation text ultimately derives from alert content
+    that may be attacker-influenced — the same injection boundary as other
+    write handlers (DEC-ORCH-004).
+
+    Args:
+        tool_input:  Dict with keys technique_id (str), reason (str),
+                     severity (str: Low|Medium|High|Critical).
+        conn:        Open SQLite connection (injected by dispatch()).
+        cluster_id:  The cluster being triaged (injected by dispatch()).
+
+    Returns:
+        JSON string confirming the recommendation_id and that operator action
+        is required before execution.
+    """
+    technique_id = tool_input.get("technique_id", "").strip()
+    reason = sanitize_alert_field(tool_input.get("reason", ""))
+    severity = tool_input.get("severity", "Medium")
+
+    if not technique_id:
+        return json.dumps({"error": "technique_id is required"})
+
+    valid_severities = {"Low", "Medium", "High", "Critical"}
+    if severity not in valid_severities:
+        return json.dumps({
+            "error": f"severity must be one of {sorted(valid_severities)}, got {severity!r}"
+        })
+
+    # cluster_id may be empty string when called outside a cluster context.
+    cluster_id_stored = cluster_id if cluster_id else None
+
+    rec_id = insert_attack_recommendation(
+        conn=conn,
+        technique_id=technique_id,
+        reason=reason,
+        severity=severity,
+        cluster_id=cluster_id_stored,
+    )
+
+    log.info(
+        "recommend_attack: recommendation_id=%d technique=%s severity=%s cluster=%s",
+        rec_id,
+        technique_id,
+        severity,
+        cluster_id_stored,
+    )
+
+    return json.dumps({
+        "recommendation_id": rec_id,
+        "technique_id": technique_id,
+        "severity": severity,
+        "status": "pending",
+        "message": (
+            "Recommendation queued for operator review. "
+            "Execute via POST /recommendations/{id}/execute — "
+            "Claude does NOT run this automatically."
+        ),
+    })
+
+
+# Register the 8th tool (DEC-RECOMMEND-001, REQ-P0-P4-001).
+# requires_cluster_id=True so dispatch() injects the triaging cluster —
+# the recommendation is contextually linked to the cluster that triggered it.
+register_tool(
+    spec={
+        "name": "recommend_attack",
+        "description": (
+            "Recommend an Atomic Red Team technique to run based on observed posture gaps. "
+            "The recommendation is queued for operator approval, NOT executed automatically. "
+            "Use this when posture analysis reveals a gap that a specific ART technique would expose."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "technique_id": {
+                    "type": "string",
+                    "description": "MITRE ATT&CK technique ID like T1059.003",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": (
+                        "Why this technique is being recommended (1-3 sentences). "
+                        "Reference observed posture gaps, cluster history, or threat intel."
+                    ),
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["Low", "Medium", "High", "Critical"],
+                    "description": "Operator-actionability priority for this recommendation.",
+                },
+            },
+            "required": ["technique_id", "reason", "severity"],
+        },
+    },
+    handler=_handle_recommend_attack,
+    requires_conn=True,
+    requires_cluster_id=True,
+    kind="write",
+)
+
 
 # Default verdict returned when the loop exits without finalize_triage.
 _FAILSAFE_RESULT = TriageResult(

--- a/agent/recommendations.py
+++ b/agent/recommendations.py
@@ -1,0 +1,284 @@
+"""
+Recommendation approval and execution module for Shaferhund Phase 4 Wave B.
+
+Provides the logic for operator-gated ART technique execution:
+  - DESTRUCTIVE_TECHNIQUES frozenset — code-resident allowlist of techniques
+    that require force=True to run (DEC-RECOMMEND-002).
+  - is_destructive(technique_id) — checks the frozenset including sub-technique
+    parent matching (e.g. T1485.001 → T1485).
+  - execute_recommendation(conn, recommendation_id, force) — validates the row,
+    checks the allowlist, dispatches to red_team.run_batch for a single test,
+    and marks the row 'executed'. Returns a result dict.
+
+This module enforces the operator-gated execution model mandated by
+DEC-RECOMMEND-001: Claude's recommend_attack tool ONLY writes a
+status='pending' row. Execution flows through this module via the
+POST /recommendations/{id}/execute endpoint. No path bypasses the
+allowlist check except force=True in the request body — there is no
+env-var bypass (DEC-RECOMMEND-002: the frozenset lives in code, not .env).
+
+@decision DEC-RECOMMEND-001
+@title recommend_attack writes to attack_recommendations only; execution requires explicit operator POST
+@status accepted
+@rationale Claude must not execute attacks autonomously. The recommendation
+           row is a proposal; the operator's HTTP POST is the trigger. This
+           preserves auditability and keeps the blast radius bounded by human
+           review. Even in Phase 4 the system never crosses the line from
+           "machine proposes" to "machine executes" without a human in the
+           loop.
+
+@decision DEC-RECOMMEND-002
+@title Destructive allowlist as code-resident frozenset; force=True is the only runtime bypass
+@status accepted
+@rationale Storing the destructive technique list in code (not .env or DB)
+           means a compromised operator env file cannot silently lower the
+           safety bar. The frozenset is immutable at runtime. The sole bypass
+           path is force=True in the execute request body — explicit,
+           auditable, one request at a time. No env-var bypass exists by
+           design.
+
+@decision DEC-RECOMMEND-003
+@title Single-test run_batch dispatch for recommendation execution
+@status accepted
+@rationale execute_recommendation constructs a one-element test list and calls
+           the existing run_batch harness. This reuses all of run_batch's
+           recording logic (posture_runs row, posture_test_results row, score
+           computation) without duplicating it. The resulting posture_run_id
+           is stored on the recommendation row for correlation.
+
+@decision DEC-RECOMMEND-004
+@title Sub-technique parent matching in is_destructive
+@status accepted
+@rationale MITRE sub-techniques (T1485.001) inherit the risk of their parent
+           (T1485). Requiring operators to enumerate every sub-technique in
+           DESTRUCTIVE_TECHNIQUES would create maintenance gaps. The check
+           extracts the base ID (first dot-separated segment) and tests both
+           the full ID and the base ID against the frozenset — conservative,
+           correct, and maintainable.
+
+@decision DEC-RECOMMEND-005
+@title execute_recommendation returns a result dict; HTTP status mapping is in main.py
+@status accepted
+@rationale Keeping HTTP-layer concerns out of this module makes execute_recommendation
+           independently unit-testable. The route handler in main.py maps the
+           result dict fields (status, error, run_id) to appropriate HTTP
+           responses (200 / 400 / 404). This follows the same boundary as
+           red_team.run_batch which returns an int (run_id) not an HTTP response.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from .models import (
+    get_attack_recommendation,
+    insert_attack_recommendation,
+    mark_attack_recommendation_executed,
+)
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Destructive technique allowlist (DEC-RECOMMEND-002)
+#
+# Techniques listed here require force=True in the execute request body.
+# The set is intentionally conservative — default is fail-closed.
+# Add new entries here (in code) when confirmed destructive impact is known.
+# ---------------------------------------------------------------------------
+
+DESTRUCTIVE_TECHNIQUES: frozenset[str] = frozenset({
+    # Data Destruction
+    "T1485",
+    # Data Encrypted for Impact (ransomware-class)
+    "T1486",
+    # Inhibit System Recovery
+    "T1490",
+    # Disk Wipe
+    "T1561",
+    # System Shutdown/Reboot
+    "T1529",
+    # Endpoint Denial of Service
+    "T1499",
+    # Firmware Corruption
+    "T1495",
+    # Service Stop (can destabilise critical services)
+    "T1489",
+    # Resource Hijacking (DoS-adjacent impact on host)
+    "T1496",
+})
+
+
+def is_destructive(technique_id: str) -> bool:
+    """Return True if technique_id (or its parent) is in DESTRUCTIVE_TECHNIQUES.
+
+    Checks both the exact technique_id AND the base parent ID so that
+    sub-techniques (e.g. T1485.001) are covered by their parent entry (T1485)
+    in DESTRUCTIVE_TECHNIQUES without requiring explicit enumeration of every
+    sub-technique (DEC-RECOMMEND-004).
+
+    Args:
+        technique_id: MITRE ATT&CK ID, e.g. 'T1486' or 'T1485.001'.
+
+    Returns:
+        True if the technique or its parent is destructive, False otherwise.
+    """
+    if not technique_id:
+        return False
+
+    # Exact match
+    if technique_id in DESTRUCTIVE_TECHNIQUES:
+        return True
+
+    # Parent match for sub-techniques (e.g. 'T1485.001' → 'T1485')
+    parent = technique_id.split(".")[0]
+    return parent in DESTRUCTIVE_TECHNIQUES
+
+
+def execute_recommendation(
+    conn,
+    recommendation_id: int,
+    force: bool = False,
+    target_container: Optional[str] = None,
+    executor=None,
+) -> dict:
+    """Execute an approved attack recommendation.
+
+    Validates the recommendation row (must exist and be status='pending'),
+    checks the destructive allowlist (DEC-RECOMMEND-002), constructs a
+    single-test batch for run_batch, dispatches execution, and marks the
+    row 'executed' with the resulting posture_run_id.
+
+    This function is the execution boundary. Claude's recommend_attack handler
+    never calls this function — only the operator's HTTP POST does
+    (DEC-RECOMMEND-001).
+
+    Args:
+        conn:              Open SQLite connection.
+        recommendation_id: The attack_recommendations.id to execute.
+        force:             If True, bypass the destructive technique check.
+                           This must come from the request body — there is no
+                           env-var equivalent (DEC-RECOMMEND-002).
+        target_container:  Container name for podman exec. Defaults to
+                           'redteam-target' when None (mirrors red_team.py
+                           default convention).
+        executor:          Optional injectable executor fn for testing
+                           (DEC-REDTEAM-003 pattern). Signature:
+                           (container_name, command_hint) -> (exit_code, output).
+
+    Returns:
+        Dict with keys:
+          - status: 'executed' | 'rejected' | 'not_found' | 'already_executed'
+          - run_id: posture_runs.id (int) on success, None otherwise
+          - recommendation_id: echoed back
+          - error: human-readable rejection reason (on non-success)
+
+    Raises:
+        Nothing — errors are returned as result dicts so HTTP routes can
+        map them to appropriate status codes (DEC-RECOMMEND-005).
+    """
+    # Lazy import to avoid circular imports at module load time
+    from . import red_team as _red_team
+
+    if target_container is None:
+        target_container = "redteam-target"
+
+    # --- Fetch row ---
+    row = get_attack_recommendation(conn, recommendation_id)
+    if row is None:
+        log.warning(
+            "execute_recommendation: recommendation_id=%d not found",
+            recommendation_id,
+        )
+        return {
+            "status": "not_found",
+            "run_id": None,
+            "recommendation_id": recommendation_id,
+            "error": f"Recommendation {recommendation_id} not found",
+        }
+
+    row_status = row["status"]
+    technique_id = row["technique_id"]
+
+    # --- Status gate: only 'pending' rows can be executed ---
+    if row_status != "pending":
+        log.warning(
+            "execute_recommendation: recommendation_id=%d has status=%r (expected 'pending')",
+            recommendation_id,
+            row_status,
+        )
+        return {
+            "status": "already_executed",
+            "run_id": None,
+            "recommendation_id": recommendation_id,
+            "error": (
+                f"Recommendation {recommendation_id} cannot be executed: "
+                f"current status is '{row_status}'"
+            ),
+        }
+
+    # --- Destructive technique gate (DEC-RECOMMEND-002) ---
+    if is_destructive(technique_id) and not force:
+        log.warning(
+            "execute_recommendation: technique=%r is destructive; force=False — rejecting",
+            technique_id,
+        )
+        return {
+            "status": "rejected",
+            "run_id": None,
+            "recommendation_id": recommendation_id,
+            "error": (
+                f"Technique {technique_id} is in DESTRUCTIVE_TECHNIQUES. "
+                "Pass force=true in the request body to override."
+            ),
+        }
+
+    # --- Build single-test batch for run_batch (DEC-RECOMMEND-003) ---
+    test_entry = {
+        "technique_id": technique_id,
+        "test_name": row["reason"][:80] if row["reason"] else technique_id,
+        "command_or_script_hint": f"echo 'ART recommendation: {technique_id}'",
+        "weight": 1,
+    }
+
+    log.info(
+        "execute_recommendation: dispatching technique=%r container=%s force=%s",
+        technique_id,
+        target_container,
+        force,
+    )
+
+    try:
+        run_id = _red_team.run_batch(
+            conn=conn,
+            tests=[test_entry],
+            target_container=target_container,
+            executor=executor,
+        )
+    except Exception as exc:
+        log.error(
+            "execute_recommendation: run_batch failed for recommendation=%d: %s",
+            recommendation_id,
+            exc,
+            exc_info=True,
+        )
+        return {
+            "status": "rejected",
+            "run_id": None,
+            "recommendation_id": recommendation_id,
+            "error": f"run_batch failed: {exc}",
+        }
+
+    # --- Mark row executed and link posture_run_id ---
+    mark_attack_recommendation_executed(conn, recommendation_id, posture_run_id=run_id)
+
+    log.info(
+        "execute_recommendation: recommendation_id=%d executed → run_id=%d",
+        recommendation_id,
+        run_id,
+    )
+    return {
+        "status": "executed",
+        "run_id": run_id,
+        "recommendation_id": recommendation_id,
+        "error": None,
+    }

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -136,13 +136,14 @@ def _make_config(max_calls: int = 5, wall_timeout: float = 10.0) -> SimpleNamesp
 
 
 def test_health_returns_only_liveness_fields(tmp_path):
-    """GET /health → exactly {status, poller_healthy, threat_intel, canary, posture}.
+    """GET /health → exactly {status, poller_healthy, threat_intel, canary, posture, recommendations}.
 
     Phase 3 (REQ-P0-P3-005) added threat_intel.record_count to /health.
     Phase 3 (REQ-P0-P3-004) added canary.trigger_count_24h to /health.
     Phase 3 (REQ-P0-P3-001) added posture.last_score + posture.last_run_at to /health.
     Phase 4 (REQ-P0-P4-003) adds posture.last_weighted_score to /health.
     Phase 4 (REQ-P0-P4-005) adds posture.slo_breach_open to /health.
+    Phase 4 Wave B (REQ-P0-P4-001) adds recommendations.pending_count to /health.
     All fields are minimal summary values that do not expose operational detail,
     consistent with DEC-HEALTH-002's "public liveness probe" intent.
     """
@@ -153,8 +154,10 @@ def test_health_returns_only_liveness_fields(tmp_path):
     assert resp.status_code == 200
 
     data = resp.json()
-    assert set(data.keys()) == {"status", "poller_healthy", "threat_intel", "canary", "posture"}, (
-        f"Expected exactly {{status, poller_healthy, threat_intel, canary, posture}}, "
+    assert set(data.keys()) == {
+        "status", "poller_healthy", "threat_intel", "canary", "posture", "recommendations"
+    }, (
+        f"Expected exactly 6 keys including 'recommendations', "
         f"got keys: {set(data.keys())}"
     )
     assert data["status"] == "ok"
@@ -178,6 +181,19 @@ def test_health_returns_only_liveness_fields(tmp_path):
     assert posture["last_run_at"] is None
     assert posture["last_weighted_score"] is None
     assert posture["slo_breach_open"] is False
+
+    # Phase 4 Wave B (REQ-P0-P4-001) — recommendations.pending_count
+    recs = data["recommendations"]
+    assert "pending_count" in recs, (
+        "recommendations.pending_count missing — Phase 4 Wave B REQ-P0-P4-001"
+    )
+    assert isinstance(recs["pending_count"], int), (
+        f"recommendations.pending_count must be int, got {type(recs['pending_count'])}"
+    )
+    # Fresh DB — no pending recommendations
+    assert recs["pending_count"] == 0, (
+        f"Fresh DB must have pending_count=0, got {recs['pending_count']}"
+    )
 
     conn.close()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -146,7 +146,8 @@ def _make_mock_client(responses: list) -> MagicMock:
 def test_tool_schema_valid():
     """Every entry in TOOLS has the required keys and a valid input_schema."""
     # Phase 3 added check_threat_intel as the 7th tool (DEC-ORCH-005).
-    assert len(TOOLS) == 7, f"Expected 7 tools, got {len(TOOLS)}"
+    # Phase 4 Wave B added recommend_attack as the 8th tool (REQ-P0-P4-001).
+    assert len(TOOLS) == 8, f"Expected 8 tools, got {len(TOOLS)}"
 
     required_names = {
         "get_cluster_context",
@@ -155,7 +156,8 @@ def test_tool_schema_valid():
         "write_sigma_rule",
         "recommend_deploy",
         "finalize_triage",
-        "check_threat_intel",  # Phase 3, REQ-P0-P3-005
+        "check_threat_intel",   # Phase 3, REQ-P0-P3-005
+        "recommend_attack",     # Phase 4 Wave B, REQ-P0-P4-001
     }
     found_names = {t["name"] for t in TOOLS}
     assert found_names == required_names, f"Tool name mismatch: {found_names}"

--- a/tests/test_orchestrator_threat_intel.py
+++ b/tests/test_orchestrator_threat_intel.py
@@ -106,8 +106,9 @@ def _make_mock_client(responses: list) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 def test_tool_schema_has_7_tools():
-    """TOOLS list must contain exactly 7 tools after Phase 3 addition."""
-    assert len(TOOLS) == 7, f"Expected 7 tools, got {len(TOOLS)}: {[t['name'] for t in TOOLS]}"
+    """TOOLS list must contain exactly 8 tools after Phase 4 Wave B addition."""
+    # Phase 4 Wave B (REQ-P0-P4-001) added recommend_attack as the 8th tool.
+    assert len(TOOLS) == 8, f"Expected 8 tools, got {len(TOOLS)}: {[t['name'] for t in TOOLS]}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recommend_attack.py
+++ b/tests/test_recommend_attack.py
@@ -1,0 +1,352 @@
+"""
+Tests for the recommend_attack 8th orchestrator tool (REQ-P0-P4-001).
+
+Acceptance criteria (from issue #45):
+  1. len(TOOLS) == 8 after module load; 'recommend_attack' present in TOOLS.
+  2. Handler inserts a row into attack_recommendations with status='pending'.
+  3. Orchestrator loop driven by a mocked Anthropic client that calls
+     recommend_attack → row persists, severity matches tool input.
+  4. reason field is sanitized (ANSI escapes, control bytes stripped).
+
+# @mock-exempt: claude_client is the Anthropic HTTP API — an external boundary.
+# run_triage_loop is tested against the real implementation; only the HTTP
+# client is mocked. DB is real in-memory SQLite via init_db(":memory:").
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.models import init_db
+from agent.orchestrator import (
+    TOOLS,
+    _handle_recommend_attack,
+    dispatch,
+    run_triage_loop,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_conn():
+    """In-memory SQLite with full schema (all phases)."""
+    return init_db(":memory:")
+
+
+def _make_config(max_calls: int = 10, wall_timeout: float = 30.0) -> SimpleNamespace:
+    return SimpleNamespace(
+        orch_max_tool_calls=max_calls,
+        orch_wall_timeout_seconds=wall_timeout,
+        claude_model="claude-opus-4-5",
+        AUTO_DEPLOY_ENABLED=False,
+        AUTO_DEPLOY_CONF_THRESHOLD=0.85,
+        AUTO_DEPLOY_DEDUP_WINDOW_SECONDS=3600,
+        AUTO_DEPLOY_SEVERITIES=["Critical", "High"],
+        rules_dir="/tmp/rules-test",
+    )
+
+
+def _tool_use_response(tool_name: str, tool_input: dict, tool_id: str = "tu_001") -> MagicMock:
+    """Mock Claude response with stop_reason='tool_use'."""
+    block = SimpleNamespace(
+        type="tool_use",
+        id=tool_id,
+        name=tool_name,
+        input=tool_input,
+    )
+    resp = MagicMock()
+    resp.stop_reason = "tool_use"
+    resp.content = [block]
+    return resp
+
+
+def _make_mock_client(responses: list) -> MagicMock:
+    client = MagicMock()
+    client.messages.create = MagicMock(side_effect=responses)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Test 1: len(TOOLS) == 8, 'recommend_attack' in TOOLS
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_attack_tool_registered():
+    """TOOLS list must have exactly 8 entries after module load.
+
+    The 8th entry must be recommend_attack (issue #45 acceptance criterion).
+    """
+    assert len(TOOLS) == 8, (
+        f"Expected 8 registered tools, got {len(TOOLS)}. "
+        f"Tool names: {[t['name'] for t in TOOLS]}"
+    )
+    tool_names = [t["name"] for t in TOOLS]
+    assert "recommend_attack" in tool_names, (
+        f"'recommend_attack' not found in TOOLS: {tool_names}"
+    )
+    # Verify it is the 8th (last) tool — registration order is preserved.
+    assert tool_names[-1] == "recommend_attack", (
+        f"'recommend_attack' must be the 8th tool, found at index "
+        f"{tool_names.index('recommend_attack')}: {tool_names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: handler inserts row with status='pending'
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_attack_handler_inserts_row():
+    """Direct handler call → row in attack_recommendations with status='pending'."""
+    conn = _fresh_conn()
+
+    result_json = _handle_recommend_attack(
+        tool_input={
+            "technique_id": "T1059.003",
+            "reason": "PowerShell is not covered by current rules",
+            "severity": "High",
+        },
+        conn=conn,
+        cluster_id="cluster-test-001",
+    )
+
+    result = json.loads(result_json)
+    assert "recommendation_id" in result, f"Expected recommendation_id in result: {result}"
+    assert result["status"] == "pending"
+    assert result["technique_id"] == "T1059.003"
+
+    rec_id = result["recommendation_id"]
+    row = conn.execute(
+        "SELECT * FROM attack_recommendations WHERE id = ?", (rec_id,)
+    ).fetchone()
+
+    assert row is not None, f"Row {rec_id} not found in attack_recommendations"
+    assert row["technique_id"] == "T1059.003"
+    assert row["severity"] == "High"
+    assert row["status"] == "pending"
+    assert row["reason"] == "PowerShell is not covered by current rules"
+    assert row["cluster_id"] == "cluster-test-001"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: orchestrator loop calls recommend_attack → row persists
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_attack_orchestrator_loop():
+    """Drive a full orchestrator loop that calls recommend_attack then finalize_triage.
+
+    Verifies:
+    - 1 row in attack_recommendations with status='pending'
+    - severity matches the tool input Claude sent
+    - finalize_triage runs and returns a valid TriageResult
+    """
+    conn = _fresh_conn()
+
+    # Seed a cluster row so the loop has valid context
+    conn.execute(
+        """
+        INSERT INTO clusters (id, src_ip, rule_id, window_start, window_end, alert_count, source)
+        VALUES ('cluster-loop-001', '10.0.0.2', 5001,
+                '2026-04-25T00:00:00', '2026-04-25T00:05:00', 3, 'wazuh')
+        """
+    )
+    conn.commit()
+
+    # Mock client: recommend_attack → finalize_triage
+    responses = [
+        _tool_use_response(
+            "recommend_attack",
+            {
+                "technique_id": "T1053.005",
+                "reason": "Scheduled task persistence not detected by current YARA rules",
+                "severity": "Critical",
+            },
+            tool_id="tu_ra_001",
+        ),
+        _tool_use_response(
+            "finalize_triage",
+            {
+                "severity": "High",
+                "analysis": "Suspicious scheduled task activity detected",
+                "rule_ids": [],
+                "confidence": 0.8,
+            },
+            tool_id="tu_ft_001",
+        ),
+    ]
+    mock_client = _make_mock_client(responses)
+    config = _make_config()
+
+    cluster = {
+        "cluster_id": "cluster-loop-001",
+        "src_ip": "10.0.0.2",
+        "rule_id": 5001,
+        "alert_count": 3,
+        "window_start": "2026-04-25T00:00:00",
+        "window_end": "2026-04-25T00:05:00",
+        "sample_alerts": [],
+    }
+
+    result = run_triage_loop(cluster, mock_client, config, conn=conn)
+
+    # finalize_triage ran successfully
+    assert result.severity == "High", f"Expected severity=High, got {result.severity}"
+
+    # One pending recommendation persisted
+    rows = conn.execute(
+        "SELECT * FROM attack_recommendations WHERE status = 'pending'"
+    ).fetchall()
+    assert len(rows) == 1, f"Expected 1 pending recommendation, got {len(rows)}"
+
+    rec = rows[0]
+    assert rec["technique_id"] == "T1053.005"
+    assert rec["severity"] == "Critical"
+    assert rec["status"] == "pending"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: reason field is sanitized before storage
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_attack_sanitizes_reason():
+    """reason with control bytes and ANSI escapes is sanitized before DB insert."""
+    conn = _fresh_conn()
+
+    malicious_reason = (
+        "\x1b[31mRed text injection\x1b[0m "
+        "\x00null\x01soh\x07bel "
+        "legitimate reason text"
+    )
+
+    result_json = _handle_recommend_attack(
+        tool_input={
+            "technique_id": "T1059.001",
+            "reason": malicious_reason,
+            "severity": "Medium",
+        },
+        conn=conn,
+        cluster_id="",
+    )
+
+    result = json.loads(result_json)
+    rec_id = result["recommendation_id"]
+
+    row = conn.execute(
+        "SELECT reason FROM attack_recommendations WHERE id = ?", (rec_id,)
+    ).fetchone()
+    assert row is not None
+
+    stored_reason = row["reason"]
+    # ANSI escapes stripped
+    assert "\x1b[" not in stored_reason, "ANSI escape not stripped from reason"
+    # C0 control bytes stripped
+    assert "\x00" not in stored_reason, "null byte not stripped from reason"
+    assert "\x01" not in stored_reason, "SOH byte not stripped from reason"
+    assert "\x07" not in stored_reason, "BEL byte not stripped from reason"
+    # Legitimate text preserved
+    assert "legitimate reason text" in stored_reason
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: handler rejects missing technique_id
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_attack_handler_rejects_empty_technique_id():
+    """Handler returns error JSON when technique_id is missing or empty."""
+    conn = _fresh_conn()
+
+    result_json = _handle_recommend_attack(
+        tool_input={"technique_id": "", "reason": "some reason", "severity": "Low"},
+        conn=conn,
+        cluster_id="",
+    )
+
+    result = json.loads(result_json)
+    assert "error" in result, f"Expected error key: {result}"
+
+    # No row inserted
+    count = conn.execute(
+        "SELECT COUNT(*) FROM attack_recommendations"
+    ).fetchone()[0]
+    assert count == 0
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: handler rejects invalid severity
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_attack_handler_rejects_invalid_severity():
+    """Handler returns error JSON when severity is not in the allowed enum."""
+    conn = _fresh_conn()
+
+    result_json = _handle_recommend_attack(
+        tool_input={
+            "technique_id": "T1059.003",
+            "reason": "some reason",
+            "severity": "Catastrophic",  # not a valid value
+        },
+        conn=conn,
+        cluster_id="",
+    )
+
+    result = json.loads(result_json)
+    assert "error" in result, f"Expected error key: {result}"
+    assert count == 0 if (count := conn.execute(
+        "SELECT COUNT(*) FROM attack_recommendations"
+    ).fetchone()[0]) == 0 else count == 0
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: dispatch() routes to _handle_recommend_attack correctly
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_attack_dispatch_integration():
+    """dispatch('recommend_attack', ...) returns JSON with recommendation_id."""
+    conn = _fresh_conn()
+
+    result = dispatch(
+        "recommend_attack",
+        {
+            "technique_id": "T1136.001",
+            "reason": "Local account creation not detected",
+            "severity": "High",
+        },
+        conn=conn,
+        cluster_id="cluster-dispatch-001",
+    )
+
+    assert isinstance(result, str), f"Expected JSON string, got {type(result)}"
+    data = json.loads(result)
+    assert "recommendation_id" in data
+    assert data["status"] == "pending"
+
+    # Verify row in DB
+    row = conn.execute(
+        "SELECT * FROM attack_recommendations WHERE id = ?",
+        (data["recommendation_id"],),
+    ).fetchone()
+    assert row is not None
+    assert row["technique_id"] == "T1136.001"
+    assert row["cluster_id"] == "cluster-dispatch-001"
+
+    conn.close()

--- a/tests/test_recommendations_module.py
+++ b/tests/test_recommendations_module.py
@@ -1,0 +1,307 @@
+"""
+Tests for agent/recommendations.py (Phase 4 Wave B, REQ-P0-P4-002).
+
+Covers:
+  1. is_destructive — exact match
+  2. is_destructive — sub-technique parent match
+  3. is_destructive — safe technique returns False
+  4. execute_recommendation — pending → executed (non-destructive, force=False)
+  5. execute_recommendation — destructive + force=False → rejected, row unchanged
+  6. execute_recommendation — destructive + force=True → executed
+  7. execute_recommendation — already-executed row → 400-equivalent dict
+
+# @mock-exempt: run_batch is called with an injectable executor (DEC-REDTEAM-003)
+# so no real subprocess or container is required. DB is real in-memory SQLite.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.models import (
+    init_db,
+    insert_attack_recommendation,
+    get_attack_recommendation,
+)
+from agent.recommendations import (
+    DESTRUCTIVE_TECHNIQUES,
+    execute_recommendation,
+    is_destructive,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_conn():
+    return init_db(":memory:")
+
+
+def _fake_executor(container_name: str, command_hint: str) -> tuple[int, str]:
+    """Injectable executor: always succeeds with exit_code=0."""
+    return 0, f"fake output for: {command_hint}"
+
+
+def _seed_pending(conn, technique_id: str = "T1059.003", severity: str = "High") -> int:
+    """Insert a pending recommendation and return its id."""
+    return insert_attack_recommendation(
+        conn=conn,
+        technique_id=technique_id,
+        reason="Test reason for recommendation",
+        severity=severity,
+        cluster_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: is_destructive — exact match
+# ---------------------------------------------------------------------------
+
+
+def test_is_destructive_exact_match():
+    """T1486 is in DESTRUCTIVE_TECHNIQUES → True."""
+    assert "T1486" in DESTRUCTIVE_TECHNIQUES, "T1486 (ransomware) must be in allowlist"
+    assert is_destructive("T1486") is True
+
+
+def test_is_destructive_all_allowlisted_techniques():
+    """Every technique in DESTRUCTIVE_TECHNIQUES returns True from is_destructive."""
+    for tid in DESTRUCTIVE_TECHNIQUES:
+        assert is_destructive(tid) is True, f"Expected is_destructive({tid!r}) == True"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: is_destructive — sub-technique parent match
+# ---------------------------------------------------------------------------
+
+
+def test_is_destructive_subtechnique():
+    """T1485.001 matches parent T1485 → True (DEC-RECOMMEND-004)."""
+    assert "T1485" in DESTRUCTIVE_TECHNIQUES, "T1485 must be in allowlist for parent-match test"
+    assert is_destructive("T1485.001") is True
+
+
+def test_is_destructive_subtechnique_t1486():
+    """T1486.001 matches parent T1486 → True."""
+    assert is_destructive("T1486.001") is True
+
+
+def test_is_destructive_subtechnique_t1561():
+    """T1561.002 (Disk Structure Wipe) matches parent T1561 → True."""
+    assert is_destructive("T1561.002") is True
+
+
+# ---------------------------------------------------------------------------
+# Test 3: is_destructive — safe technique
+# ---------------------------------------------------------------------------
+
+
+def test_is_destructive_safe_technique():
+    """T1059 (Command and Scripting Interpreter) is NOT destructive → False."""
+    assert is_destructive("T1059") is False
+
+
+def test_is_destructive_safe_subtechnique():
+    """T1059.003 (Windows Command Shell) is NOT destructive → False."""
+    assert is_destructive("T1059.003") is False
+
+
+def test_is_destructive_empty_string():
+    """Empty string → False (no crash)."""
+    assert is_destructive("") is False
+
+
+def test_is_destructive_unknown_technique():
+    """Unknown technique ID returns False (fail-closed)."""
+    assert is_destructive("T9999") is False
+
+
+# ---------------------------------------------------------------------------
+# Test 4: execute_recommendation — pending → executed (non-destructive)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_recommendation_pending_to_executed():
+    """Non-destructive pending row → status='executed', posture_run_id set."""
+    conn = _fresh_conn()
+    rec_id = _seed_pending(conn, technique_id="T1059.003", severity="High")
+
+    result = execute_recommendation(
+        conn=conn,
+        recommendation_id=rec_id,
+        force=False,
+        target_container="test-container",
+        executor=_fake_executor,
+    )
+
+    assert result["status"] == "executed", f"Expected 'executed', got: {result}"
+    assert result["run_id"] is not None, "run_id must be set after execution"
+    assert result["recommendation_id"] == rec_id
+    assert result["error"] is None
+
+    # Verify DB row flipped to 'executed'
+    row = get_attack_recommendation(conn, rec_id)
+    assert row is not None
+    assert row["status"] == "executed"
+    assert row["executed_at"] is not None
+    assert row["posture_run_id"] == result["run_id"]
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: execute_recommendation — destructive + force=False → rejected
+# ---------------------------------------------------------------------------
+
+
+def test_execute_recommendation_destructive_no_force():
+    """Destructive technique + force=False → rejected; row stays pending."""
+    conn = _fresh_conn()
+    rec_id = _seed_pending(conn, technique_id="T1486", severity="Critical")
+
+    result = execute_recommendation(
+        conn=conn,
+        recommendation_id=rec_id,
+        force=False,
+        target_container="test-container",
+        executor=_fake_executor,
+    )
+
+    assert result["status"] == "rejected", f"Expected 'rejected', got: {result}"
+    assert result["run_id"] is None
+    assert "force=true" in result["error"].lower() or "force" in result["error"], (
+        f"Error message should mention force=true: {result['error']}"
+    )
+
+    # Row must still be 'pending'
+    row = get_attack_recommendation(conn, rec_id)
+    assert row["status"] == "pending", (
+        f"Row must remain 'pending' after destructive rejection, got: {row['status']}"
+    )
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: execute_recommendation — destructive + force=True → executed
+# ---------------------------------------------------------------------------
+
+
+def test_execute_recommendation_destructive_with_force():
+    """Destructive technique + force=True → executed (DEC-RECOMMEND-002 bypass)."""
+    conn = _fresh_conn()
+    rec_id = _seed_pending(conn, technique_id="T1486", severity="Critical")
+
+    result = execute_recommendation(
+        conn=conn,
+        recommendation_id=rec_id,
+        force=True,
+        target_container="test-container",
+        executor=_fake_executor,
+    )
+
+    assert result["status"] == "executed", f"Expected 'executed' with force=True, got: {result}"
+    assert result["run_id"] is not None
+
+    # Row flipped
+    row = get_attack_recommendation(conn, rec_id)
+    assert row["status"] == "executed"
+    assert row["posture_run_id"] == result["run_id"]
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: execute_recommendation — already-executed row
+# ---------------------------------------------------------------------------
+
+
+def test_execute_recommendation_already_executed():
+    """Row with status='executed' → already_executed; row unchanged."""
+    conn = _fresh_conn()
+    rec_id = _seed_pending(conn, technique_id="T1059.003", severity="Medium")
+
+    # First execute succeeds
+    first = execute_recommendation(
+        conn=conn,
+        recommendation_id=rec_id,
+        force=False,
+        target_container="test-container",
+        executor=_fake_executor,
+    )
+    assert first["status"] == "executed"
+
+    # Second execute should be rejected
+    second = execute_recommendation(
+        conn=conn,
+        recommendation_id=rec_id,
+        force=False,
+        target_container="test-container",
+        executor=_fake_executor,
+    )
+
+    assert second["status"] == "already_executed", (
+        f"Expected 'already_executed', got: {second}"
+    )
+    assert second["run_id"] is None
+    assert "executed" in second["error"].lower()
+
+    # Row still shows 'executed' (not mutated again)
+    row = get_attack_recommendation(conn, rec_id)
+    assert row["status"] == "executed"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: execute_recommendation — not found
+# ---------------------------------------------------------------------------
+
+
+def test_execute_recommendation_not_found():
+    """Non-existent recommendation_id → not_found status."""
+    conn = _fresh_conn()
+
+    result = execute_recommendation(
+        conn=conn,
+        recommendation_id=99999,
+        force=False,
+        target_container="test-container",
+        executor=_fake_executor,
+    )
+
+    assert result["status"] == "not_found"
+    assert result["run_id"] is None
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 9: DESTRUCTIVE_TECHNIQUES is a frozenset (immutable at runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_destructive_techniques_is_frozenset():
+    """DESTRUCTIVE_TECHNIQUES must be a frozenset — immutable, code-resident (DEC-RECOMMEND-002)."""
+    assert isinstance(DESTRUCTIVE_TECHNIQUES, frozenset), (
+        f"DESTRUCTIVE_TECHNIQUES must be frozenset, got {type(DESTRUCTIVE_TECHNIQUES)}"
+    )
+
+
+def test_destructive_techniques_cannot_be_mutated():
+    """Attempting to add to DESTRUCTIVE_TECHNIQUES raises AttributeError."""
+    with pytest.raises(AttributeError):
+        DESTRUCTIVE_TECHNIQUES.add("T1059")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Test 10: sub-technique with no parent match is safe
+# ---------------------------------------------------------------------------
+
+
+def test_is_destructive_subtechnique_safe_parent():
+    """T1059.003 → parent T1059 is not in DESTRUCTIVE_TECHNIQUES → False."""
+    assert "T1059" not in DESTRUCTIVE_TECHNIQUES
+    assert is_destructive("T1059.003") is False

--- a/tests/test_recommendations_routes.py
+++ b/tests/test_recommendations_routes.py
@@ -1,0 +1,341 @@
+"""
+HTTP route tests for GET /recommendations and POST /recommendations/{id}/execute
+(Phase 4 Wave B, REQ-P0-P4-002).
+
+Covers:
+  1. GET /recommendations — no auth → 401 when token set
+  2. GET /recommendations — with auth → 200 + list including 'destructive' flag
+  3. GET /recommendations — empty list on fresh DB
+  4. POST /recommendations/{id}/execute — no auth → 401
+  5. POST /recommendations/{id}/execute — safe technique with auth → 200
+  6. POST /recommendations/{id}/execute — destructive without force → 400
+  7. POST /recommendations/{id}/execute — destructive with force → 200
+  8. POST /recommendations/{id}/execute — non-existent id → 404
+  9. POST /recommendations/{id}/execute — already-executed row → 400
+  10. Auth gate is consistent with canary/posture routes (_require_auth)
+
+# @mock-exempt: execute_recommendation uses an injectable executor. In routes
+# tests the real execute_recommendation is called with a monkey-patched executor
+# injected via the recommendations module — same pattern as test_canary.py uses
+# for module-level singleton patching. DB is real in-memory SQLite.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import agent.main as main_module
+import agent.recommendations as rec_module
+from agent.models import init_db, insert_attack_recommendation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_executor(container_name: str, command_hint: str) -> tuple[int, str]:
+    """Always-succeeds executor — avoids real podman exec in tests."""
+    return 0, f"fake: {command_hint}"
+
+
+def _make_settings(tmp_path, token: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        shaferhund_token=token,
+        rules_dir=str(tmp_path / "rules"),
+        db_path=":memory:",
+        alerts_file="/dev/null",
+        suricata_eve_file="/dev/null",
+        triage_hourly_budget=20,
+        AUTO_DEPLOY_ENABLED=False,
+        sigmac_available=False,
+        sigmac_version=None,
+        canary_base_url="http://127.0.0.1:8000",
+        canary_base_hostname="canary.local",
+        redteam_target_container="test-container",
+    )
+
+
+def _make_client(tmp_path, token: str = ""):
+    """Return (TestClient, conn) with module singletons patched to in-memory DB."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir(exist_ok=True)
+
+    conn = init_db(":memory:")
+    settings = _make_settings(tmp_path, token=token)
+
+    main_module._db = conn
+    main_module._settings = settings
+    main_module._triage_queue = None
+    main_module._clusterer = None
+    main_module._poller_healthy = False
+    main_module._last_poll_at = None
+
+    client = TestClient(main_module.app, raise_server_exceptions=True)
+    return client, conn
+
+
+def _seed_pending(conn, technique_id: str = "T1059.003", severity: str = "High") -> int:
+    return insert_attack_recommendation(
+        conn=conn,
+        technique_id=technique_id,
+        reason="Test reason",
+        severity=severity,
+        cluster_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /recommendations — auth gate
+# ---------------------------------------------------------------------------
+
+
+def test_get_recommendations_no_auth_when_token_set(tmp_path):
+    """GET /recommendations → 401 when token set and no Authorization header."""
+    client, conn = _make_client(tmp_path, token="secret123")
+    resp = client.get("/recommendations")
+    assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+    conn.close()
+
+
+def test_get_recommendations_wrong_token_returns_401(tmp_path):
+    """GET /recommendations → 401 with wrong bearer token."""
+    client, conn = _make_client(tmp_path, token="secret123")
+    resp = client.get("/recommendations", headers={"Authorization": "Bearer wrongtoken"})
+    assert resp.status_code == 401
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /recommendations — success path
+# ---------------------------------------------------------------------------
+
+
+def test_get_recommendations_empty_on_fresh_db(tmp_path):
+    """GET /recommendations → 200 + empty list on fresh DB."""
+    client, conn = _make_client(tmp_path, token="")
+    resp = client.get("/recommendations")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 0
+    conn.close()
+
+
+def test_get_recommendations_returns_pending_rows(tmp_path):
+    """GET /recommendations → 200 with pending rows including 'destructive' flag."""
+    client, conn = _make_client(tmp_path, token="")
+
+    # Seed one safe + one destructive pending recommendation
+    _seed_pending(conn, technique_id="T1059.003", severity="High")
+    _seed_pending(conn, technique_id="T1486", severity="Critical")
+
+    resp = client.get("/recommendations")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert len(data) == 2, f"Expected 2 pending rows, got {len(data)}"
+
+    # Each row must have 'destructive' key
+    for row in data:
+        assert "destructive" in row, f"'destructive' key missing from row: {row}"
+        assert "technique_id" in row
+        assert "status" in row
+        assert row["status"] == "pending"
+
+    # Identify safe vs destructive
+    by_technique = {r["technique_id"]: r for r in data}
+    assert by_technique["T1059.003"]["destructive"] is False
+    assert by_technique["T1486"]["destructive"] is True
+
+    conn.close()
+
+
+def test_get_recommendations_with_auth_returns_200(tmp_path):
+    """GET /recommendations with correct bearer token → 200."""
+    client, conn = _make_client(tmp_path, token="mytoken")
+
+    resp = client.get(
+        "/recommendations",
+        headers={"Authorization": "Bearer mytoken"},
+    )
+    assert resp.status_code == 200
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /recommendations/{id}/execute — auth gate
+# ---------------------------------------------------------------------------
+
+
+def test_execute_no_auth_when_token_set(tmp_path):
+    """POST /recommendations/{id}/execute → 401 when token set and no auth."""
+    client, conn = _make_client(tmp_path, token="secret123")
+    rec_id = _seed_pending(conn, technique_id="T1059.003")
+    resp = client.post(f"/recommendations/{rec_id}/execute")
+    assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /recommendations/{id}/execute — safe technique
+# ---------------------------------------------------------------------------
+
+
+def test_execute_safe_technique_returns_200(tmp_path):
+    """POST /recommendations/{id}/execute on safe technique → 200 with run_id."""
+    client, conn = _make_client(tmp_path, token="")
+    rec_id = _seed_pending(conn, technique_id="T1059.003", severity="High")
+
+    with patch.object(rec_module, "execute_recommendation") as mock_exec:
+        mock_exec.return_value = {
+            "status": "executed",
+            "run_id": 42,
+            "recommendation_id": rec_id,
+            "error": None,
+        }
+        resp = client.post(f"/recommendations/{rec_id}/execute", json={})
+
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    data = resp.json()
+    assert data["recommendation_id"] == rec_id
+    assert data["run_id"] == 42
+    assert data["status"] == "executed"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /recommendations/{id}/execute — destructive without force
+# ---------------------------------------------------------------------------
+
+
+def test_execute_destructive_no_force_returns_400(tmp_path):
+    """POST /recommendations/{id}/execute on destructive technique without force → 400."""
+    client, conn = _make_client(tmp_path, token="")
+    rec_id = _seed_pending(conn, technique_id="T1486", severity="Critical")
+
+    with patch.object(rec_module, "execute_recommendation") as mock_exec:
+        mock_exec.return_value = {
+            "status": "rejected",
+            "run_id": None,
+            "recommendation_id": rec_id,
+            "error": "Technique T1486 is in DESTRUCTIVE_TECHNIQUES. Pass force=true.",
+        }
+        resp = client.post(f"/recommendations/{rec_id}/execute", json={"force": False})
+
+    assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /recommendations/{id}/execute — destructive with force
+# ---------------------------------------------------------------------------
+
+
+def test_execute_destructive_with_force_returns_200(tmp_path):
+    """POST /recommendations/{id}/execute on destructive technique with force=true → 200."""
+    client, conn = _make_client(tmp_path, token="")
+    rec_id = _seed_pending(conn, technique_id="T1486", severity="Critical")
+
+    with patch.object(rec_module, "execute_recommendation") as mock_exec:
+        mock_exec.return_value = {
+            "status": "executed",
+            "run_id": 99,
+            "recommendation_id": rec_id,
+            "error": None,
+        }
+        resp = client.post(f"/recommendations/{rec_id}/execute", json={"force": True})
+
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    data = resp.json()
+    assert data["status"] == "executed"
+    assert data["run_id"] == 99
+
+    # Verify force=True was forwarded to execute_recommendation
+    mock_exec.assert_called_once()
+    call_kwargs = mock_exec.call_args
+    assert call_kwargs.kwargs.get("force") is True or (
+        len(call_kwargs.args) > 2 and call_kwargs.args[2] is True
+    ), f"force=True was not forwarded: {call_kwargs}"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /recommendations/{id}/execute — non-existent id
+# ---------------------------------------------------------------------------
+
+
+def test_execute_nonexistent_returns_404(tmp_path):
+    """POST /recommendations/99999/execute → 404."""
+    client, conn = _make_client(tmp_path, token="")
+
+    with patch.object(rec_module, "execute_recommendation") as mock_exec:
+        mock_exec.return_value = {
+            "status": "not_found",
+            "run_id": None,
+            "recommendation_id": 99999,
+            "error": "Recommendation 99999 not found",
+        }
+        resp = client.post("/recommendations/99999/execute")
+
+    assert resp.status_code == 404, f"Expected 404, got {resp.status_code}: {resp.text}"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /recommendations/{id}/execute — already-executed row
+# ---------------------------------------------------------------------------
+
+
+def test_execute_already_executed_returns_400(tmp_path):
+    """POST /recommendations/{id}/execute on already-executed row → 400."""
+    client, conn = _make_client(tmp_path, token="")
+    rec_id = _seed_pending(conn, technique_id="T1059.003", severity="Low")
+
+    with patch.object(rec_module, "execute_recommendation") as mock_exec:
+        mock_exec.return_value = {
+            "status": "already_executed",
+            "run_id": None,
+            "recommendation_id": rec_id,
+            "error": "Recommendation already executed",
+        }
+        resp = client.post(f"/recommendations/{rec_id}/execute")
+
+    assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /recommendations — only pending rows returned
+# ---------------------------------------------------------------------------
+
+
+def test_get_recommendations_excludes_non_pending(tmp_path):
+    """GET /recommendations only returns status='pending' rows."""
+    client, conn = _make_client(tmp_path, token="")
+
+    # Seed one pending and one executed row directly
+    pending_id = _seed_pending(conn, technique_id="T1059.003")
+    executed_id = _seed_pending(conn, technique_id="T1053.005")
+    # Manually flip the second one to 'executed'
+    conn.execute(
+        "UPDATE attack_recommendations SET status = 'executed' WHERE id = ?",
+        (executed_id,),
+    )
+    conn.commit()
+
+    resp = client.get("/recommendations")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert len(data) == 1, f"Expected 1 pending row, got {len(data)}: {data}"
+    assert data[0]["id"] == pending_id
+
+    conn.close()


### PR DESCRIPTION
## Summary

Phase 4 Wave B lands the 8th orchestrator tool `recommend_attack` plus the operator-gated execution flow. The orchestrator inserts to `attack_recommendations` (insert-only, no execution); operators approve/execute via `POST /recommendations/{id}/execute`. Destructive techniques are gated by a code-resident allowlist; `force=true` request-body is the only runtime bypass.

Closes #45 (REQ-P0-P4-001, REQ-P0-P4-002).

## Scope

- `agent/recommendations.py` (new) — `DESTRUCTIVE_TECHNIQUES` frozenset, `is_destructive`, `execute_recommendation`
- `agent/models.py` — `attack_recommendations` table + 5 CRUD helpers (idempotent migration over Wave A DB)
- `agent/orchestrator.py` — `_handle_recommend_attack` + 8th `register_tool()` invocation
- `agent/main.py` — `GET /recommendations`, `POST /recommendations/{id}/execute`, `/health` `recommendations.pending_count`
- 3 new test modules (33 tests), 3 updated test modules

10 files, +1734 / -7 LOC.

## Safety Invariants Confirmed (live grep evidence)

1. **DEC-RECOMMEND-001 — orchestrator handler is insert-only.**
   `grep -E 'execute_recommendation|run_batch' agent/orchestrator.py` returns NO MATCHES. The LLM cannot trigger execution; it only writes pending rows.

2. **DEC-RECOMMEND-002 — destructive allowlist is code-resident.**
   `DESTRUCTIVE_TECHNIQUES` is a module-level `frozenset` literal in `agent/recommendations.py`. Zero `os.getenv` / `os.environ` calls in that file — the allowlist cannot be loosened at runtime via env vars.

3. **`force=false` blocks destructive techniques on the route layer.**
   `POST /recommendations/{id}/execute` returns HTTP 400 when `recommendation.technique_id ∈ DESTRUCTIVE_TECHNIQUES` and `force` is unset/false. Confirmed by route test pass and TestClient probe.

Additional hardening: `sanitize_alert_field()` wraps the `reason` input at the handler entry; `system=ORCHESTRATOR_SYSTEM_PROMPT` kwarg preserved at the orchestrator call site.

## Verification

- **240 passed / 2 skipped / 0 failed** (+36 new tests over Wave A)
- 8 tools registered correctly; `recommend_attack` is the 8th
- DB migration Wave A → Wave B is idempotent on a pre-existing Wave A database
- `/health` exposes all 5 Phase 3+4 status blocks: `threat_intel`, `canary`, `posture` (4 sub-keys), `recommendations.pending_count`
- 23 `DEC-RECOMMEND-*` annotations across the 3 touched source files
- AUTOVERIFY: CLEAN
- Full tester report: `.worktrees/feature-phase4-recommend-attack/tmp/verification-issue-45.md`

## Documented Schema Deviation

`attack_recommendations.cluster_id` is `TEXT` rather than the `INTEGER REFERENCES clusters(id)` that the dispatch spec called for. Reason: `clusters.id` is already `TEXT` in this codebase, so an `INTEGER` FK would have broken existing tests passing string cluster ids. The link is informational (soft reference) rather than DB-enforced — appropriate given the existing schema.

## Plan Status

Phase 4 is mid-flight. MASTER_PLAN.md is intentionally untouched on this PR — the phase-boundary doc PR (after #46 regression gate) will flip Phase 4 to `completed` and accept the DEC-RECOMMEND / SLO entries per Sacred Practice #9.