### PR TITLE
feat(#55): cloud findings + deterministic detector + /cloud/findings (REQ-P0-P5-005)

### DIFF
--- a/agent/cloud_findings.py
+++ b/agent/cloud_findings.py
@@ -1,0 +1,344 @@
+"""
+Deterministic cloud-audit finding detector for Shaferhund Phase 5 Wave A2.
+
+Implements REQ-P0-P5-005: a small, fast, side-effect-free module that runs
+every CloudTrail alert through a list of code-resident detector rules and
+persists findings to cloud_audit_findings via the models layer.
+
+Design decisions captured here:
+
+@decision DEC-CLOUD-005
+@title Detection rules are code-resident, not loaded from env or DB
+@status accepted
+@rationale Storing detection patterns in code (not .env, not a DB table, not a
+           YAML file loaded at startup) means:
+           1. A compromised environment cannot disable critical detections by
+              unsetting env vars or truncating a config table.
+           2. Every rule change goes through code review — the audit trail is
+              the git log, not a DB mutation.
+           3. The rule set is visible to any reader of this file without DB
+              access — operators can reason about what fires without querying.
+           Same rationale as DEC-RECOMMEND-002 (DESTRUCTIVE_TECHNIQUES frozenset)
+           and DEC-RECOMMEND-005 (Phase 4 safety surfaces). Rules are a list of
+           dicts (not a frozenset) because each rule carries a callable matcher
+           and string templates — frozenset requires hashable members.
+
+@decision DEC-CLOUD-007
+@title evaluate_event is synchronous and called in-process after each alert insert
+@status accepted
+@rationale Cloud findings are deterministic (no LLM), cheap (dict key access +
+           one DB INSERT), and benefit from running synchronously so a finding
+           is visible by the time the cluster lands. A background task would add
+           complexity without reducing latency — the caller already runs on the
+           asyncio loop. See MASTER_PLAN.md Phase 5 Engineering Decision 11.
+
+@decision DEC-CLOUD-008
+@title Rule matchers are pure functions (event: dict) -> bool
+@status accepted
+@rationale Pure functions are trivially testable, composable, and have no
+           hidden dependencies. Each rule's 'matches' key holds a lambda or
+           named function. No shared state, no DB access inside matchers.
+           evaluate_event() handles all DB writes after the match check.
+
+Public API:
+    RULES  — list of rule dicts (module-level constant, code-resident)
+    evaluate_event(conn, alert_id, event) -> list[int]
+"""
+
+import json
+import logging
+import sqlite3
+from typing import Optional
+
+from .models import insert_cloud_finding
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helper: extract principal string from userIdentity
+# ---------------------------------------------------------------------------
+
+
+def _principal(event: dict) -> str:
+    """Extract a human-readable principal from a CloudTrail userIdentity block.
+
+    Tries userName, then arn, then type as fallbacks. Returns 'unknown' when
+    the event has no userIdentity block at all.
+    """
+    uid = event.get("userIdentity") or {}
+    return (
+        uid.get("userName")
+        or uid.get("arn")
+        or uid.get("type", "unknown")
+    )
+
+
+def _src_ip(event: dict) -> str:
+    """Return sourceIPAddress or 'unknown'."""
+    return event.get("sourceIPAddress") or "unknown"
+
+
+def _event_name(event: dict) -> str:
+    return event.get("eventName", "")
+
+
+def _event_source(event: dict) -> str:
+    return event.get("eventSource", "")
+
+
+def _req(event: dict) -> dict:
+    """Return requestParameters dict, or {} when absent/null."""
+    return event.get("requestParameters") or {}
+
+
+# ---------------------------------------------------------------------------
+# Code-resident rule list (DEC-CLOUD-005)
+# ---------------------------------------------------------------------------
+#
+# Each rule is a dict with:
+#   name            — machine-readable rule identifier (used as rule_name in DB)
+#   severity        — one of 'Low', 'Medium', 'High', 'Critical'
+#   title_template  — str.format_map()-compatible template for the finding title
+#   description     — static description of why this matters
+#   matches         — callable(event: dict) -> bool
+#
+# title_template keys: {src_ip}, {principal}, {event_name}, {event_source},
+#                      {bucket_name}, {user_name}, {target_user}
+# Extra keys are ignored by format_map (we use a defaultdict-style fallback).
+#
+
+class _SafeDict(dict):
+    """dict subclass that returns '{key}' for missing keys in format_map.
+
+    Prevents KeyError when a title_template references a field absent from
+    the event (e.g. 'requestParameters.bucketName' on an IAM event).
+    """
+    def __missing__(self, key: str) -> str:
+        return f"{{{key}}}"
+
+
+def _make_title(template: str, event: dict) -> str:
+    """Render a title_template with event-derived values, never raising KeyError."""
+    ctx = _SafeDict(
+        src_ip=_src_ip(event),
+        principal=_principal(event),
+        event_name=_event_name(event),
+        event_source=_event_source(event),
+        bucket_name=_req(event).get("bucketName", "unknown"),
+        user_name=_req(event).get("userName", "unknown"),
+        target_user=_req(event).get("userName", "unknown"),
+    )
+    return template.format_map(ctx)
+
+
+RULES: list[dict] = [
+    # ------------------------------------------------------------------
+    # Rule 1: root_console_login (Critical)
+    # Root user should never log in via the console directly.
+    # AWS best practice: root account is for emergency break-glass only,
+    # never daily use, and never console login.
+    # ------------------------------------------------------------------
+    {
+        "name": "root_console_login",
+        "severity": "Critical",
+        "title_template": "Root user console login from {src_ip}",
+        "description": (
+            "The AWS root account logged in via the management console. "
+            "Root account use is a high-severity event: the root user bypasses "
+            "all IAM policies and has unrestricted access to every AWS resource. "
+            "This should be investigated immediately. If the login was unexpected, "
+            "rotate root credentials and enable MFA."
+        ),
+        "matches": lambda e: (
+            e.get("eventName") == "ConsoleLogin"
+            and (e.get("userIdentity") or {}).get("type") == "Root"
+        ),
+    },
+
+    # ------------------------------------------------------------------
+    # Rule 2: mfa_disabled_for_user (High)
+    # Disabling MFA weakens authentication for the affected principal.
+    # Common attacker tactic: disable MFA on a compromised account to
+    # prevent the legitimate owner from regaining access easily.
+    # ------------------------------------------------------------------
+    {
+        "name": "mfa_disabled_for_user",
+        "severity": "High",
+        "title_template": "MFA deactivated for {principal}",
+        "description": (
+            "Multi-factor authentication was deactivated for an IAM user. "
+            "MFA disabling is a common post-compromise step — an attacker who "
+            "gains API access to an account may disable MFA to lock the legitimate "
+            "owner out of recovery paths. Verify whether this change was authorised "
+            "and re-enable MFA immediately if not."
+        ),
+        "matches": lambda e: e.get("eventName") == "DeactivateMFADevice",
+    },
+
+    # ------------------------------------------------------------------
+    # Rule 3: iam_user_created (Medium)
+    # New IAM users created outside provisioning pipelines are a red flag.
+    # Attackers persist in AWS accounts by creating backdoor IAM users.
+    # ------------------------------------------------------------------
+    {
+        "name": "iam_user_created",
+        "severity": "Medium",
+        "title_template": "IAM user created: {user_name} by {principal}",
+        "description": (
+            "A new IAM user was created. Unexpected IAM user creation is a "
+            "persistence tactic — attackers create backdoor accounts to maintain "
+            "access after their initial entry vector is closed. Verify that the "
+            "creating principal is an authorised provisioning pipeline or operator, "
+            "and that the new user follows the least-privilege naming convention."
+        ),
+        "matches": lambda e: (
+            e.get("eventName") == "CreateUser"
+            and e.get("eventSource") == "iam.amazonaws.com"
+        ),
+    },
+
+    # ------------------------------------------------------------------
+    # Rule 4: s3_bucket_policy_changed (Medium)
+    # Bucket policy changes can expose data publicly or grant cross-account
+    # access — a common exfiltration setup.
+    # ------------------------------------------------------------------
+    {
+        "name": "s3_bucket_policy_changed",
+        "severity": "Medium",
+        "title_template": "S3 bucket policy changed on {bucket_name}",
+        "description": (
+            "An S3 bucket policy was modified. Bucket policy changes can make "
+            "data publicly accessible, grant access to external AWS accounts, or "
+            "remove protective controls (e.g. denying non-encrypted uploads). "
+            "Review the new policy to confirm it follows the principle of least "
+            "privilege and does not introduce unintended public access."
+        ),
+        "matches": lambda e: (
+            e.get("eventName") == "PutBucketPolicy"
+            and e.get("eventSource") == "s3.amazonaws.com"
+        ),
+    },
+
+    # ------------------------------------------------------------------
+    # Rule 5: access_key_created (Medium)
+    # Long-lived access keys are a persistent credential risk.
+    # Attackers create access keys on compromised accounts to maintain
+    # API-level access independently of console password rotation.
+    # ------------------------------------------------------------------
+    {
+        "name": "access_key_created",
+        "severity": "Medium",
+        "title_template": "Access key created for {target_user}",
+        "description": (
+            "A new IAM access key was created. Long-lived access keys are a "
+            "persistent credential risk: they do not expire automatically, are "
+            "not subject to MFA, and are frequently leaked via code commits or "
+            "misconfigured services. Attackers create access keys on compromised "
+            "accounts to maintain API-level access even after console passwords "
+            "are rotated. Verify that the key creation was intentional and that "
+            "the key will be rotated per your organisation's policy."
+        ),
+        "matches": lambda e: (
+            e.get("eventName") == "CreateAccessKey"
+            and e.get("eventSource") == "iam.amazonaws.com"
+        ),
+    },
+]
+
+# Sanity check at import time: each rule has the required keys and a callable matcher.
+# This is a development-time guard — it fires on import, not in tests.
+_REQUIRED_RULE_KEYS = {"name", "severity", "title_template", "description", "matches"}
+for _rule in RULES:
+    _missing = _REQUIRED_RULE_KEYS - _rule.keys()
+    if _missing:
+        raise ValueError(
+            f"cloud_findings rule {_rule.get('name', '?')} is missing keys: {_missing}"
+        )
+    if not callable(_rule["matches"]):
+        raise ValueError(
+            f"cloud_findings rule {_rule['name']}: 'matches' must be callable"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_event(
+    conn: sqlite3.Connection,
+    alert_id: Optional[str],
+    event: dict,
+) -> list[int]:
+    """Run every detector rule against a CloudTrail event dict.
+
+    For each rule whose matches() returns True, inserts a row into
+    cloud_audit_findings via insert_cloud_finding() and collects the
+    resulting finding ID.
+
+    This function is synchronous and side-effect-bearing (writes to DB).
+    It is designed to be called immediately after insert_cloudtrail_alert()
+    in the ingestion path (DEC-CLOUD-007).
+
+    Args:
+        conn:     Open SQLite connection (real connection, not a factory —
+                  per DEC-SLO-004, isinstance checks are used by callers;
+                  this function accepts a raw conn only).
+        alert_id: The alert ID string returned by insert_cloudtrail_alert(),
+                  or None for standalone evaluation (tests / re-processing).
+        event:    A single CloudTrail event record dict (one element of
+                  Records[]). Must contain at least 'eventName';
+                  other fields are extracted with safe .get() fallbacks.
+
+    Returns:
+        List of integer finding IDs created during this call. Empty list
+        when no rules match.
+    """
+    finding_ids: list[int] = []
+    principal = _principal(event)
+    src_ip = _src_ip(event)
+    event_name = _event_name(event)
+    event_source = _event_source(event)
+    raw_event_json = json.dumps(event)
+
+    for rule in RULES:
+        try:
+            matched = rule["matches"](event)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "cloud_findings: rule %s matcher raised %s — skipping",
+                rule["name"], exc,
+            )
+            matched = False
+
+        if not matched:
+            continue
+
+        title = _make_title(rule["title_template"], event)
+
+        try:
+            finding_id = insert_cloud_finding(
+                conn=conn,
+                alert_id=alert_id,
+                rule_name=rule["name"],
+                rule_severity=rule["severity"],
+                title=title,
+                description=rule["description"],
+                principal=principal,
+                src_ip=src_ip,
+                event_name=event_name,
+                event_source=event_source,
+                raw_event=raw_event_json,
+            )
+            finding_ids.append(finding_id)
+            log.debug(
+                "cloud_findings: rule=%s alert_id=%s finding_id=%d",
+                rule["name"], alert_id, finding_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.error(
+                "cloud_findings: failed to persist finding for rule %s: %s",
+                rule["name"], exc, exc_info=True,
+            )
+
+    return finding_ids

--- a/agent/main.py
+++ b/agent/main.py
@@ -102,8 +102,10 @@ from .canary import spawn_canary, record_hit, count_canary_triggers_since
 from . import red_team as _red_team
 from .models import (
     count_pending_attack_recommendations,
+    count_cloud_findings,
     get_attack_recommendation,
     get_latest_posture_run,
+    list_cloud_findings,
     get_open_slo_breach,
     insert_posture_run,
     list_pending_attack_recommendations,
@@ -943,6 +945,70 @@ async def execute_recommendation_route(
         "run_id": result["run_id"],
         "status": "executed",
     })
+
+
+# ---------------------------------------------------------------------------
+# Cloud findings route (Phase 5 Wave A2, REQ-P0-P5-005)
+# ---------------------------------------------------------------------------
+
+
+@app.get(
+    "/cloud/findings",
+    dependencies=[Depends(_require_auth)],
+)
+async def list_cloud_findings_route(
+    limit: int = 50,
+    severity: Optional[str] = None,
+) -> JSONResponse:
+    """List cloud audit findings for operator review.
+
+    Auth-gated via _require_auth — same bearer token scheme as /recommendations
+    and /metrics (DEC-AUTH-001, DEC-AUTH-002).
+
+    Query params:
+        limit    — Max rows to return. Default 50, capped at 200.
+        severity — Optional filter: Low | Medium | High | Critical.
+                   When absent, all severities are returned.
+
+    Returns:
+        JSON array of finding objects, newest-first. Each object includes
+        all cloud_audit_findings columns plus a derived ``event_age_seconds``
+        field (seconds since detected_at, for operator situational awareness).
+
+    Empty array when no findings exist.
+
+    @decision DEC-CLOUD-005
+    @title GET /cloud/findings exposes deterministic detector output; auth-gated
+    @status accepted
+    @rationale The findings table is fed exclusively by code-resident detector
+               rules (DEC-CLOUD-005). This route surfaces them for operator
+               review without any LLM involvement. Auth gate matches all
+               other operator-facing routes (DEC-AUTH-001).
+    """
+    if _db is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    # Cap limit at 200 to prevent runaway queries
+    effective_limit = min(max(1, limit), 200)
+
+    rows = list_cloud_findings(_db, limit=effective_limit, severity=severity)
+
+    now_ts = datetime.now(timezone.utc)
+    result = []
+    for row in rows:
+        finding = dict(row)
+        # Derive event_age_seconds from detected_at
+        try:
+            detected_dt = datetime.fromisoformat(finding["detected_at"])
+            if detected_dt.tzinfo is None:
+                detected_dt = detected_dt.replace(tzinfo=timezone.utc)
+            age = max(0, int((now_ts - detected_dt).total_seconds()))
+        except (ValueError, TypeError):
+            age = 0
+        finding["event_age_seconds"] = age
+        result.append(finding)
+
+    return JSONResponse(result)
 
 
 async def _canary_enqueue(alert_obj) -> None:

--- a/agent/models.py
+++ b/agent/models.py
@@ -37,6 +37,16 @@ insert_cloudtrail_alert.
            one cursor row per configured (bucket, prefix) pair regardless of
            how many times init_db runs.
 
+@decision DEC-CLOUD-005
+@title cloud_audit_findings detector rules are code-resident, not DB/env-loaded
+@status accepted
+@rationale The set of detected patterns (root login, MFA disable, IAM user
+           create, etc.) is reviewed at code-review time in agent/cloud_findings.py.
+           Storing rules in DB or .env would let an attacker who compromises
+           the environment silently disable detections. Code-resident rules
+           are immutable at runtime — same reasoning as DEC-RECOMMEND-002 for
+           DESTRUCTIVE_TECHNIQUES. New patterns require a PR, which is auditable.
+
 @decision DEC-POSTURE-003
 @title Weighted posture score — declarative YAML weights, additive alongside flat score
 @status accepted
@@ -439,6 +449,56 @@ CREATE TABLE IF NOT EXISTS cloudtrail_progress (
 """
 
 
+# ---------------------------------------------------------------------------
+# Phase 5 Wave A2 schema additions — cloud_audit_findings table
+# (REQ-P0-P5-005, DEC-CLOUD-005)
+# ---------------------------------------------------------------------------
+#
+# cloud_audit_findings captures deterministic detector hits on CloudTrail
+# events. One row per (alert_id, rule_name) finding — alert_id is the FK
+# to alerts.id (a TEXT UUID from insert_cloudtrail_alert).
+#
+# DEC-CLOUD-005: detection rules are code-resident in agent/cloud_findings.py,
+#   not loaded from env or DB. Same rationale as DEC-RECOMMEND-002 for
+#   DESTRUCTIVE_TECHNIQUES — reviewers see what fires; env-var compromise
+#   cannot disable detections.
+# DEC-SCHEMA-002: CREATE TABLE IF NOT EXISTS — idempotent for all prior DBs.
+#
+# Columns:
+#   alert_id     — FK to alerts.id (TEXT UUID from insert_cloudtrail_alert).
+#   rule_name    — Detector rule that fired (e.g. 'root_console_login').
+#   rule_severity — 'Low'|'Medium'|'High'|'Critical' — CHECK constraint.
+#   title        — Human-readable title with interpolated fields.
+#   description  — Free-form description of why this finding matters.
+#   principal    — ARN or username of the IAM principal involved.
+#   src_ip       — Source IP from the CloudTrail event.
+#   event_name   — CloudTrail eventName (e.g. 'ConsoleLogin').
+#   event_source — CloudTrail eventSource (e.g. 'signin.amazonaws.com').
+#   detected_at  — UTC ISO-8601 timestamp when the finding was created.
+#   raw_event    — Full raw CloudTrail event JSON (for operator drill-down).
+_CLOUD_AUDIT_FINDINGS_SQL = """
+CREATE TABLE IF NOT EXISTS cloud_audit_findings (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    alert_id        TEXT    REFERENCES alerts(id),
+    rule_name       TEXT    NOT NULL,
+    rule_severity   TEXT    NOT NULL CHECK(rule_severity IN ('Low','Medium','High','Critical')),
+    title           TEXT    NOT NULL,
+    description     TEXT    NOT NULL,
+    principal       TEXT,
+    src_ip          TEXT,
+    event_name      TEXT,
+    event_source    TEXT,
+    detected_at     TEXT    NOT NULL,
+    raw_event       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_audit_findings_detected_at
+    ON cloud_audit_findings(detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cloud_audit_findings_severity
+    ON cloud_audit_findings(rule_severity);
+"""
+
+
 def init_db(db_path: str) -> sqlite3.Connection:
     """Open (or create) the SQLite database and apply schema.
 
@@ -540,6 +600,9 @@ def init_db(db_path: str) -> sqlite3.Connection:
 
     # Phase 5 Wave A1: cloudtrail_progress table (REQ-P0-P5-001, DEC-CLOUD-011).
     conn.executescript(_CLOUDTRAIL_PROGRESS_SQL)
+
+    # Phase 5 Wave A2: cloud_audit_findings table (REQ-P0-P5-005, DEC-CLOUD-005).
+    conn.executescript(_CLOUD_AUDIT_FINDINGS_SQL)
 
     conn.commit()
     log.info("Database initialised at %s", db_path)
@@ -1933,3 +1996,141 @@ def insert_cloudtrail_alert(
         )
 
     return alert_id
+
+
+# ---------------------------------------------------------------------------
+# Cloud Audit Findings CRUD  (Phase 5 Wave A2 — REQ-P0-P5-005)
+# ---------------------------------------------------------------------------
+
+
+def insert_cloud_finding(
+    conn: sqlite3.Connection,
+    alert_id: Optional[str],
+    rule_name: str,
+    rule_severity: str,
+    title: str,
+    description: str,
+    principal: Optional[str],
+    src_ip: Optional[str],
+    event_name: Optional[str],
+    event_source: Optional[str],
+    raw_event: Optional[str],
+) -> int:
+    """Insert a cloud audit finding row and return its integer id.
+
+    Sets detected_at to the current UTC ISO-8601 timestamp.
+
+    Args:
+        conn:          Open SQLite connection.
+        alert_id:      FK to alerts.id (TEXT UUID), or None for standalone findings.
+        rule_name:     Name of the detector rule that fired.
+        rule_severity: One of 'Low', 'Medium', 'High', 'Critical'.
+        title:         Human-readable title (interpolated with event fields).
+        description:   Free-form description of the finding.
+        principal:     IAM principal ARN or username.
+        src_ip:        Source IP from the CloudTrail event.
+        event_name:    CloudTrail eventName.
+        event_source:  CloudTrail eventSource.
+        raw_event:     Full raw CloudTrail event as a JSON string.
+
+    Returns:
+        The integer primary key of the newly inserted row.
+    """
+    detected_at = datetime.now(timezone.utc).isoformat()
+    with get_cursor(conn) as cur:
+        cur.execute(
+            """
+            INSERT INTO cloud_audit_findings
+                (alert_id, rule_name, rule_severity, title, description,
+                 principal, src_ip, event_name, event_source, detected_at, raw_event)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                alert_id,
+                rule_name,
+                rule_severity,
+                title,
+                description,
+                principal,
+                src_ip,
+                event_name,
+                event_source,
+                detected_at,
+                raw_event,
+            ),
+        )
+        return cur.lastrowid
+
+
+def list_cloud_findings(
+    conn: sqlite3.Connection,
+    limit: int = 50,
+    severity: Optional[str] = None,
+) -> list:
+    """Return cloud_audit_findings rows, newest first.
+
+    Args:
+        conn:     Open SQLite connection.
+        limit:    Maximum number of rows to return (default 50).
+        severity: Optional severity filter — one of 'Low', 'Medium', 'High',
+                  'Critical'. When None, all severities are returned.
+
+    Returns:
+        List of sqlite3.Row objects ordered by detected_at DESC.
+    """
+    if severity is not None:
+        rows = conn.execute(
+            """
+            SELECT * FROM cloud_audit_findings
+            WHERE rule_severity = ?
+            ORDER BY detected_at DESC
+            LIMIT ?
+            """,
+            (severity, limit),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT * FROM cloud_audit_findings
+            ORDER BY detected_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    return rows
+
+
+def count_cloud_findings(conn: sqlite3.Connection) -> int:
+    """Return the total number of cloud_audit_findings rows.
+
+    Used by Wave A3 (#56) for /health/metrics. Included here since A3 is the
+    next issue and this helper belongs in models alongside the other count_*
+    helpers.
+
+    Args:
+        conn: Open SQLite connection.
+
+    Returns:
+        Integer count of all rows in cloud_audit_findings.
+    """
+    row = conn.execute("SELECT COUNT(*) FROM cloud_audit_findings").fetchone()
+    return row[0] if row else 0
+
+
+def get_cloud_finding(
+    conn: sqlite3.Connection,
+    finding_id: int,
+) -> Optional[sqlite3.Row]:
+    """Fetch a single cloud_audit_findings row by primary key.
+
+    Args:
+        conn:       Open SQLite connection.
+        finding_id: The INTEGER PRIMARY KEY of the finding.
+
+    Returns:
+        sqlite3.Row if found, None otherwise.
+    """
+    return conn.execute(
+        "SELECT * FROM cloud_audit_findings WHERE id = ?",
+        (finding_id,),
+    ).fetchone()

--- a/agent/sources/cloudtrail.py
+++ b/agent/sources/cloudtrail.py
@@ -99,6 +99,7 @@ from ..models import (  # noqa: E402 — after conditional boto3 import
     insert_cloudtrail_alert,
     update_cloudtrail_cursor,
 )
+from ..cloud_findings import evaluate_event as _evaluate_event  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -425,8 +426,14 @@ async def cloudtrail_poll_loop(
                 last_event_ts: Optional[str] = None
                 for obj_key, raw_event in events:
                     parsed = parse_cloudtrail_event(raw_event)
-                    await asyncio.to_thread(
+                    alert_id = await asyncio.to_thread(
                         insert_cloudtrail_alert, conn, parsed
+                    )
+                    # Run deterministic finding detector synchronously in the
+                    # thread pool (DEC-CLOUD-007). evaluate_event writes
+                    # cloud_audit_findings rows for any matching rules.
+                    await asyncio.to_thread(
+                        _evaluate_event, conn, alert_id, raw_event
                     )
                     new_last_key = obj_key
                     last_event_ts = parsed["timestamp"]

--- a/tests/fixtures/cloudtrail_iam_create_user.json
+++ b/tests/fixtures/cloudtrail_iam_create_user.json
@@ -1,0 +1,35 @@
+{
+  "eventVersion": "1.08",
+  "userIdentity": {
+    "type": "IAMUser",
+    "principalId": "AIDAEXAMPLEID123",
+    "arn": "arn:aws:iam::123456789012:user/alice",
+    "accountId": "123456789012",
+    "userName": "alice"
+  },
+  "eventTime": "2026-04-25T03:15:00Z",
+  "eventSource": "iam.amazonaws.com",
+  "eventName": "CreateUser",
+  "awsRegion": "us-east-1",
+  "sourceIPAddress": "203.0.113.77",
+  "userAgent": "aws-cli/2.15.0 Python/3.12.0 Linux/6.1.0 botocore/2.0.0",
+  "requestParameters": {
+    "userName": "backdoor-svc"
+  },
+  "responseElements": {
+    "user": {
+      "path": "/",
+      "userName": "backdoor-svc",
+      "userId": "AIDABACKDOORID456",
+      "arn": "arn:aws:iam::123456789012:user/backdoor-svc",
+      "createDate": "Apr 25, 2026 3:15:00 AM"
+    }
+  },
+  "requestID": "a2b3c4d5-e6f7-8901-abcd-ef1234567890",
+  "eventID": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "readOnly": false,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "123456789012",
+  "eventCategory": "Management"
+}

--- a/tests/fixtures/cloudtrail_root_login.json
+++ b/tests/fixtures/cloudtrail_root_login.json
@@ -1,0 +1,31 @@
+{
+  "eventVersion": "1.08",
+  "userIdentity": {
+    "type": "Root",
+    "principalId": "123456789012",
+    "arn": "arn:aws:iam::123456789012:root",
+    "accountId": "123456789012"
+  },
+  "eventTime": "2026-04-25T05:00:00Z",
+  "eventSource": "signin.amazonaws.com",
+  "eventName": "ConsoleLogin",
+  "awsRegion": "us-east-1",
+  "sourceIPAddress": "198.51.100.42",
+  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+  "requestParameters": null,
+  "responseElements": {
+    "ConsoleLogin": "Success"
+  },
+  "additionalEventData": {
+    "LoginTo": "https://console.aws.amazon.com/console/home",
+    "MobileVersion": "No",
+    "MFAUsed": "No"
+  },
+  "requestID": "c1d2e3f4-a5b6-7890-cdef-123456789012",
+  "eventID": "d1e2f3a4-b5c6-7890-defa-234567890123",
+  "readOnly": false,
+  "eventType": "AwsConsoleSignIn",
+  "managementEvent": true,
+  "recipientAccountId": "123456789012",
+  "eventCategory": "Management"
+}

--- a/tests/test_cloud_findings.py
+++ b/tests/test_cloud_findings.py
@@ -1,0 +1,367 @@
+"""
+Tests for agent.cloud_findings — deterministic detector rules + evaluate_event.
+
+Covers:
+  - Each of the 5+ detector rules (match + no-match cases)
+  - evaluate_event() persistence to cloud_audit_findings
+  - evaluate_event() return value = list of created finding IDs
+  - Code-resident rule list assertion (DEC-CLOUD-005)
+  - Multiple rules firing on a single event (when overlaps exist)
+
+All DB interactions use a real in-memory SQLite connection (Sacred Practice #5).
+No mocks on internal modules.
+
+@decision DEC-CLOUD-006
+@title Real SQLite for DB tests; no mocks on internal detector
+@status accepted
+@rationale The detector and DB layer are internal — tests exercise them
+           directly against a real in-memory SQLite schema. There is nothing
+           to mock. External boundaries (boto3 S3) are mocked in
+           test_cloudtrail_source.py; this file has no external dependencies.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.cloud_findings import RULES, evaluate_event
+from agent.models import init_db, insert_cloudtrail_alert
+from agent.sources.cloudtrail import parse_cloudtrail_event
+
+# ---------------------------------------------------------------------------
+# Fixture paths
+# ---------------------------------------------------------------------------
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+ROOT_LOGIN_FIXTURE = _FIXTURE_DIR / "cloudtrail_root_login.json"
+IAM_CREATE_USER_FIXTURE = _FIXTURE_DIR / "cloudtrail_iam_create_user.json"
+
+
+# ---------------------------------------------------------------------------
+# Shared DB fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def conn():
+    """Fresh in-memory SQLite DB per test."""
+    c = init_db(":memory:")
+    yield c
+    c.close()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic event builders
+# ---------------------------------------------------------------------------
+
+
+def _base_event() -> dict:
+    """Minimal valid CloudTrail event dict."""
+    return {
+        "eventVersion": "1.08",
+        "userIdentity": {
+            "type": "IAMUser",
+            "principalId": "AIDAEXAMPLE",
+            "arn": "arn:aws:iam::123456789012:user/testuser",
+            "accountId": "123456789012",
+            "userName": "testuser",
+        },
+        "eventTime": "2026-04-25T06:00:00Z",
+        "eventSource": "ec2.amazonaws.com",
+        "eventName": "DescribeInstances",
+        "awsRegion": "us-east-1",
+        "sourceIPAddress": "198.51.100.1",
+        "requestParameters": None,
+        "responseElements": None,
+        "requestID": "req-001",
+        "eventID": "evt-001",
+        "readOnly": True,
+        "eventType": "AwsApiCall",
+    }
+
+
+def _root_console_login_event() -> dict:
+    e = _base_event()
+    e["userIdentity"] = {"type": "Root", "principalId": "123456789012", "arn": "arn:aws:iam::123456789012:root"}
+    e["eventName"] = "ConsoleLogin"
+    e["eventSource"] = "signin.amazonaws.com"
+    e["sourceIPAddress"] = "198.51.100.42"
+    return e
+
+
+def _iam_user_event() -> dict:
+    """ConsoleLogin from a normal IAMUser — should NOT match root_console_login."""
+    e = _base_event()
+    e["eventName"] = "ConsoleLogin"
+    e["eventSource"] = "signin.amazonaws.com"
+    return e
+
+
+def _mfa_deactivated_event() -> dict:
+    e = _base_event()
+    e["eventName"] = "DeactivateMFADevice"
+    e["eventSource"] = "iam.amazonaws.com"
+    e["requestParameters"] = {"userName": "alice", "serialNumber": "arn:aws:iam::123456789012:mfa/alice"}
+    return e
+
+
+def _create_user_event() -> dict:
+    e = _base_event()
+    e["eventName"] = "CreateUser"
+    e["eventSource"] = "iam.amazonaws.com"
+    e["requestParameters"] = {"userName": "backdoor-svc"}
+    return e
+
+
+def _put_bucket_policy_event() -> dict:
+    e = _base_event()
+    e["eventName"] = "PutBucketPolicy"
+    e["eventSource"] = "s3.amazonaws.com"
+    e["requestParameters"] = {"bucketName": "my-sensitive-bucket", "policy": "{}"}
+    return e
+
+
+def _create_access_key_event() -> dict:
+    e = _base_event()
+    e["eventName"] = "CreateAccessKey"
+    e["eventSource"] = "iam.amazonaws.com"
+    e["requestParameters"] = {"userName": "ci-deploy"}
+    return e
+
+
+def _describe_instances_event() -> dict:
+    """Read-only, benign — should not match any rule."""
+    return _base_event()  # DescribeInstances on ec2.amazonaws.com
+
+
+# ---------------------------------------------------------------------------
+# Rule match tests
+# ---------------------------------------------------------------------------
+
+
+def test_root_console_login_matches(conn):
+    """Root + ConsoleLogin -> finding with rule_name='root_console_login', severity='Critical'."""
+    event = _root_console_login_event()
+    finding_ids = evaluate_event(conn, None, event)
+
+    assert len(finding_ids) >= 1
+    row = conn.execute(
+        "SELECT * FROM cloud_audit_findings WHERE id = ?", (finding_ids[0],)
+    ).fetchone()
+    assert row is not None
+    assert row["rule_name"] == "root_console_login"
+    assert row["rule_severity"] == "Critical"
+    assert "198.51.100.42" in row["title"]
+
+
+def test_root_console_login_does_not_match_iam_user(conn):
+    """IAMUser + ConsoleLogin -> root_console_login rule should NOT fire."""
+    event = _iam_user_event()
+    finding_ids = evaluate_event(conn, None, event)
+
+    # No finding should carry rule_name='root_console_login'
+    root_findings = [
+        fid for fid in finding_ids
+        if conn.execute(
+            "SELECT rule_name FROM cloud_audit_findings WHERE id = ?", (fid,)
+        ).fetchone()["rule_name"] == "root_console_login"
+    ]
+    assert root_findings == []
+
+
+def test_iam_user_created_matches(conn):
+    """CreateUser on iam.amazonaws.com -> finding with severity='Medium', principal extracted."""
+    event = _create_user_event()
+    finding_ids = evaluate_event(conn, None, event)
+
+    rows = conn.execute(
+        "SELECT * FROM cloud_audit_findings WHERE rule_name = 'iam_user_created'"
+    ).fetchall()
+    assert len(rows) >= 1
+    row = rows[0]
+    assert row["rule_severity"] == "Medium"
+    # principal is the creating user (testuser), title includes the new user name
+    assert "backdoor-svc" in row["title"]
+
+
+def test_mfa_deactivated_matches(conn):
+    """DeactivateMFADevice -> mfa_disabled_for_user fires."""
+    event = _mfa_deactivated_event()
+    finding_ids = evaluate_event(conn, None, event)
+
+    rows = conn.execute(
+        "SELECT * FROM cloud_audit_findings WHERE rule_name = 'mfa_disabled_for_user'"
+    ).fetchall()
+    assert len(rows) >= 1
+    assert rows[0]["rule_severity"] == "High"
+
+
+def test_s3_bucket_policy_changed_matches(conn):
+    """PutBucketPolicy on s3.amazonaws.com -> fires; bucket name extracted to title."""
+    event = _put_bucket_policy_event()
+    finding_ids = evaluate_event(conn, None, event)
+
+    rows = conn.execute(
+        "SELECT * FROM cloud_audit_findings WHERE rule_name = 's3_bucket_policy_changed'"
+    ).fetchall()
+    assert len(rows) >= 1
+    assert rows[0]["rule_severity"] == "Medium"
+    assert "my-sensitive-bucket" in rows[0]["title"]
+
+
+def test_access_key_created_matches(conn):
+    """CreateAccessKey on iam.amazonaws.com -> access_key_created fires."""
+    event = _create_access_key_event()
+    finding_ids = evaluate_event(conn, None, event)
+
+    rows = conn.execute(
+        "SELECT * FROM cloud_audit_findings WHERE rule_name = 'access_key_created'"
+    ).fetchall()
+    assert len(rows) >= 1
+    assert rows[0]["rule_severity"] == "Medium"
+    assert "ci-deploy" in rows[0]["title"]
+
+
+def test_no_match_for_describe_event(conn):
+    """DescribeInstances (read-only, no sensitive action) -> no findings."""
+    event = _describe_instances_event()
+    finding_ids = evaluate_event(conn, None, event)
+    assert finding_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Persistence and return-value tests
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_event_persists_findings(conn):
+    """Matching event with alert_id=42 -> cloud_audit_findings row with correct FK."""
+    # Insert a real alert so the FK is satisfiable (alert_id is TEXT in this schema)
+    parsed = parse_cloudtrail_event(_root_console_login_event())
+    alert_id = insert_cloudtrail_alert(conn, parsed)
+
+    finding_ids = evaluate_event(conn, alert_id, _root_console_login_event())
+
+    assert len(finding_ids) >= 1
+    row = conn.execute(
+        "SELECT * FROM cloud_audit_findings WHERE id = ?", (finding_ids[0],)
+    ).fetchone()
+    assert row is not None
+    assert row["alert_id"] == alert_id
+
+
+def test_evaluate_event_returns_finding_ids(conn):
+    """Return value length matches the number of rows actually created."""
+    event = _root_console_login_event()
+    finding_ids = evaluate_event(conn, None, event)
+
+    db_count = conn.execute(
+        "SELECT COUNT(*) FROM cloud_audit_findings"
+    ).fetchone()[0]
+    assert len(finding_ids) == db_count
+    assert all(isinstance(fid, int) for fid in finding_ids)
+
+
+def test_multiple_rules_can_fire_for_one_event(conn):
+    """Root + CreateAccessKey on iam.amazonaws.com -> both root-adjacent rules and access_key_created fire.
+
+    Root user events are Critical. If the root user ALSO triggers CreateAccessKey
+    on iam.amazonaws.com, both root_console_login (if ConsoleLogin) and
+    access_key_created would need to match — but those are mutually exclusive
+    (different eventName). Instead we test Root + CreateAccessKey: the root
+    heuristic makes severity Critical via _classify_severity, but rule matching
+    in cloud_findings is purely on eventName/eventSource. A Root user running
+    CreateAccessKey will match access_key_created (eventName + eventSource match).
+    The root_console_login rule fires only on ConsoleLogin. So for a root CreateAccessKey:
+      - access_key_created MATCHES (eventName=CreateAccessKey, eventSource=iam)
+      - root_console_login does NOT match (eventName != ConsoleLogin)
+    This test confirms at least 1 rule fires and the finding is persisted.
+    """
+    event = _base_event()
+    event["userIdentity"] = {
+        "type": "Root",
+        "principalId": "123456789012",
+        "arn": "arn:aws:iam::123456789012:root",
+    }
+    event["eventName"] = "CreateAccessKey"
+    event["eventSource"] = "iam.amazonaws.com"
+    event["requestParameters"] = {"userName": "root"}
+
+    finding_ids = evaluate_event(conn, None, event)
+    # access_key_created should fire
+    assert len(finding_ids) >= 1
+    rule_names = [
+        conn.execute(
+            "SELECT rule_name FROM cloud_audit_findings WHERE id = ?", (fid,)
+        ).fetchone()["rule_name"]
+        for fid in finding_ids
+    ]
+    assert "access_key_created" in rule_names
+
+
+# ---------------------------------------------------------------------------
+# Code-resident assertion (DEC-CLOUD-005)
+# ---------------------------------------------------------------------------
+
+
+def test_detector_is_code_resident():
+    """RULES is a Python list of dicts at module scope — not from env or DB.
+
+    Asserts:
+    1. RULES is a list (not loaded from DB/env at call time).
+    2. Each element is a dict with required keys.
+    3. Each element's 'matches' is callable.
+    4. The module has >= 5 rules (spec requirement).
+    """
+    import agent.cloud_findings as cf_module
+
+    # The constant is a list, not a generator, not a function result
+    assert isinstance(cf_module.RULES, list), "RULES must be a module-level list"
+
+    # At least 5 rules required by spec
+    assert len(cf_module.RULES) >= 5, f"Expected >= 5 rules, got {len(cf_module.RULES)}"
+
+    required_keys = {"name", "severity", "title_template", "description", "matches"}
+    for rule in cf_module.RULES:
+        assert isinstance(rule, dict), f"Rule must be dict, got {type(rule)}"
+        missing = required_keys - rule.keys()
+        assert not missing, f"Rule {rule.get('name', '?')} missing keys: {missing}"
+        assert callable(rule["matches"]), f"Rule {rule['name']} 'matches' must be callable"
+
+    # Confirm RULES is not lazily loaded from an env var or DB
+    # (by verifying it is populated immediately on import, not via a function call)
+    assert len(cf_module.RULES) > 0, "RULES must be non-empty at import time"
+
+
+# ---------------------------------------------------------------------------
+# Fixture-based tests
+# ---------------------------------------------------------------------------
+
+
+def test_root_login_fixture_matches(conn):
+    """The committed cloudtrail_root_login.json fixture fires root_console_login."""
+    event = json.loads(ROOT_LOGIN_FIXTURE.read_text())
+    finding_ids = evaluate_event(conn, None, event)
+
+    rule_names = [
+        conn.execute(
+            "SELECT rule_name FROM cloud_audit_findings WHERE id = ?", (fid,)
+        ).fetchone()["rule_name"]
+        for fid in finding_ids
+    ]
+    assert "root_console_login" in rule_names
+
+
+def test_iam_create_user_fixture_matches(conn):
+    """The committed cloudtrail_iam_create_user.json fixture fires iam_user_created."""
+    event = json.loads(IAM_CREATE_USER_FIXTURE.read_text())
+    finding_ids = evaluate_event(conn, None, event)
+
+    rule_names = [
+        conn.execute(
+            "SELECT rule_name FROM cloud_audit_findings WHERE id = ?", (fid,)
+        ).fetchone()["rule_name"]
+        for fid in finding_ids
+    ]
+    assert "iam_user_created" in rule_names

--- a/tests/test_cloud_findings_routes.py
+++ b/tests/test_cloud_findings_routes.py
@@ -1,0 +1,261 @@
+"""
+HTTP route tests for GET /cloud/findings (Phase 5 Wave A2, REQ-P0-P5-005).
+
+Covers:
+  1. GET /cloud/findings — no auth → 401 when token set
+  2. GET /cloud/findings — with auth → 200, [] on empty DB
+  3. GET /cloud/findings — seeded rows → 200, correct count + newest-first
+  4. GET /cloud/findings?severity=Critical — filters correctly
+  5. GET /cloud/findings?limit=5 — honours limit param
+  6. GET /cloud/findings?limit=999 — caps at 200
+
+DB: real in-memory SQLite (Sacred Practice #5).
+No mocks on internal modules.
+
+@decision DEC-CLOUD-009
+@title Route tests use real in-memory SQLite + TestClient, no mocks on models
+@status accepted
+@rationale The route, model helpers, and DB schema are all internal.
+           Mocking any of them would test the mock, not the integration.
+           TestClient runs the full FastAPI stack including auth middleware.
+"""
+
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import agent.main as main_module
+from agent.models import init_db, insert_cloud_finding
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(tmp_path, token: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        shaferhund_token=token,
+        rules_dir=str(tmp_path / "rules"),
+        db_path=":memory:",
+        alerts_file="/dev/null",
+        suricata_eve_file="/dev/null",
+        triage_hourly_budget=20,
+        AUTO_DEPLOY_ENABLED=False,
+        sigmac_available=False,
+        sigmac_version=None,
+        canary_base_url="http://127.0.0.1:8000",
+        canary_base_hostname="canary.local",
+        redteam_target_container="test-container",
+    )
+
+
+def _make_client(tmp_path, token: str = ""):
+    """Return (TestClient, conn) with module singletons wired to an in-memory DB."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir(exist_ok=True)
+
+    conn = init_db(":memory:")
+    settings = _make_settings(tmp_path, token=token)
+
+    main_module._db = conn
+    main_module._settings = settings
+    main_module._triage_queue = None
+    main_module._clusterer = None
+    main_module._poller_healthy = False
+    main_module._last_poll_at = None
+
+    client = TestClient(main_module.app, raise_server_exceptions=True)
+    return client, conn
+
+
+def _seed_finding(
+    conn,
+    rule_name: str = "root_console_login",
+    rule_severity: str = "Critical",
+    title: str = "Root user console login from 198.51.100.42",
+) -> int:
+    """Insert a cloud_audit_findings row and return its id."""
+    return insert_cloud_finding(
+        conn=conn,
+        alert_id=None,
+        rule_name=rule_name,
+        rule_severity=rule_severity,
+        title=title,
+        description="Test description",
+        principal="arn:aws:iam::123456789012:root",
+        src_ip="198.51.100.42",
+        event_name="ConsoleLogin",
+        event_source="signin.amazonaws.com",
+        raw_event='{"eventName": "ConsoleLogin"}',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth gate tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_findings_no_auth(tmp_path):
+    """GET /cloud/findings → 401 when SHAFERHUND_TOKEN is set and no header sent."""
+    client, conn = _make_client(tmp_path, token="secrettoken")
+    resp = client.get("/cloud/findings")
+    assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+    conn.close()
+
+
+def test_get_findings_wrong_token(tmp_path):
+    """GET /cloud/findings → 401 with wrong bearer token."""
+    client, conn = _make_client(tmp_path, token="secrettoken")
+    resp = client.get("/cloud/findings", headers={"Authorization": "Bearer wrongtoken"})
+    assert resp.status_code == 401
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Success path — empty DB
+# ---------------------------------------------------------------------------
+
+
+def test_get_findings_with_auth_empty(tmp_path):
+    """GET /cloud/findings with auth on empty DB → 200, []."""
+    client, conn = _make_client(tmp_path, token="")
+    resp = client.get("/cloud/findings")
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    assert resp.json() == []
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Seeded rows
+# ---------------------------------------------------------------------------
+
+
+def test_get_findings_returns_seeded_rows(tmp_path):
+    """Insert 3 findings via models helper → GET returns 3 rows newest-first."""
+    client, conn = _make_client(tmp_path, token="")
+
+    id1 = _seed_finding(conn, rule_name="root_console_login", rule_severity="Critical")
+    id2 = _seed_finding(conn, rule_name="mfa_disabled_for_user", rule_severity="High")
+    id3 = _seed_finding(conn, rule_name="iam_user_created", rule_severity="Medium")
+
+    resp = client.get("/cloud/findings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3, f"Expected 3 findings, got {len(data)}"
+
+    # Required fields present on every row
+    for row in data:
+        for field in (
+            "id", "alert_id", "rule_name", "rule_severity",
+            "title", "description", "principal", "src_ip",
+            "event_name", "event_source", "detected_at", "event_age_seconds",
+        ):
+            assert field in row, f"Field '{field}' missing from row: {row.keys()}"
+
+    # Newest-first: detected_at values should be non-increasing
+    timestamps = [row["detected_at"] for row in data]
+    assert timestamps == sorted(timestamps, reverse=True) or len(set(timestamps)) == 1, (
+        f"Rows not in newest-first order: {timestamps}"
+    )
+
+    conn.close()
+
+
+def test_get_findings_event_age_seconds_is_non_negative(tmp_path):
+    """event_age_seconds derived field should be >= 0 for a freshly inserted finding."""
+    client, conn = _make_client(tmp_path, token="")
+    _seed_finding(conn)
+
+    resp = client.get("/cloud/findings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["event_age_seconds"] >= 0
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Severity filter
+# ---------------------------------------------------------------------------
+
+
+def test_get_findings_severity_filter(tmp_path):
+    """Insert 2 Low + 1 Critical → ?severity=Critical returns only the Critical one."""
+    client, conn = _make_client(tmp_path, token="")
+
+    _seed_finding(conn, rule_name="access_key_created", rule_severity="Low", title="Low finding 1")
+    _seed_finding(conn, rule_name="s3_bucket_policy_changed", rule_severity="Low", title="Low finding 2")
+    _seed_finding(conn, rule_name="root_console_login", rule_severity="Critical", title="Critical finding")
+
+    resp = client.get("/cloud/findings?severity=Critical")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1, f"Expected 1 Critical finding, got {len(data)}: {data}"
+    assert data[0]["rule_severity"] == "Critical"
+    assert data[0]["rule_name"] == "root_console_login"
+
+    conn.close()
+
+
+def test_get_findings_severity_filter_returns_all_when_absent(tmp_path):
+    """No ?severity param → all severities returned."""
+    client, conn = _make_client(tmp_path, token="")
+
+    _seed_finding(conn, rule_severity="Critical")
+    _seed_finding(conn, rule_severity="High")
+    _seed_finding(conn, rule_severity="Medium")
+
+    resp = client.get("/cloud/findings")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Limit param
+# ---------------------------------------------------------------------------
+
+
+def test_get_findings_limit_param(tmp_path):
+    """Insert 10 findings → GET with ?limit=5 returns exactly 5."""
+    client, conn = _make_client(tmp_path, token="")
+
+    for i in range(10):
+        _seed_finding(conn, rule_name="access_key_created", title=f"Finding {i}")
+
+    resp = client.get("/cloud/findings?limit=5")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 5
+    conn.close()
+
+
+def test_get_findings_limit_caps_at_200(tmp_path):
+    """?limit=999 → server caps at 200 (max allowed)."""
+    client, conn = _make_client(tmp_path, token="")
+
+    # Insert 210 findings so we can verify the cap, not just the DB row count
+    for i in range(210):
+        _seed_finding(conn, rule_name="access_key_created", title=f"Finding {i}")
+
+    resp = client.get("/cloud/findings?limit=999")
+    assert resp.status_code == 200
+    # Must not return more than 200 regardless of DB row count
+    assert len(resp.json()) <= 200
+    conn.close()
+
+
+def test_get_findings_default_limit_is_50(tmp_path):
+    """No limit param → default is 50; inserting 60 rows returns 50."""
+    client, conn = _make_client(tmp_path, token="")
+
+    for i in range(60):
+        _seed_finding(conn, rule_name="access_key_created", title=f"Finding {i}")
+
+    resp = client.get("/cloud/findings")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 50
+    conn.close()


### PR DESCRIPTION
## Summary

Phase 5 Wave A2 — deterministic detector for high-signal CloudTrail anomalies, persisted findings, and an auth-gated read API. Closes #55 (REQ-P0-P5-005).

## Scope

- `agent/cloud_findings.py` (new, 344 lines): `RULES` list (code-resident, no env-var bypass — DEC-CLOUD-005 mirrors DEC-RECOMMEND-002 from #45) + `evaluate_event()`
- `agent/models.py`: `cloud_audit_findings` table (12 cols, FK to alerts) + 4 CRUD helpers
- `agent/sources/cloudtrail.py`: detector wired into poll loop after each alert insert
- `agent/main.py`: `GET /cloud/findings` route (auth-gated, severity filter, limit cap=200)
- 23 new tests + 2 fixtures

## Detector Rules

| Rule | Severity |
|------|----------|
| `root_console_login` | Critical |
| `mfa_disabled_for_user` | High |
| `iam_user_created` | Medium |
| `s3_bucket_policy_changed` | Medium |
| `access_key_created` | Medium |

## Verification (AUTOVERIFY: CLEAN, user-approved)

- 289 passed / 2 skipped / 0 failed (+21 new over Wave A1 baseline)
- All 5 rules fire on trigger events; `DescribeInstances` produces 0 findings (no false positive)
- End-to-end: fixture root login -> `parse_cloudtrail_event` -> `insert_cloudtrail_alert` -> `evaluate_event` -> `GET /cloud/findings` (auth=200, no-auth=401)
- Route filters: `?severity=Critical` -> 3/8; `?limit=999` capped at 8 (under 200)
- Rules are code-resident (no `os.getenv` / DB-loaded rules)
- TOOLS still 8 (Wave B1 #57 owns the 9th)
- `/health` unchanged (Wave A3 #56 owns the cloudtrail block)
- DB migration A1 -> A2 idempotent
- DEC-CLOUD-005/007/008 annotations present in `cloud_findings.py`

Full tester report: `tmp/verification-issue-55.md`

## Acceptance Criteria

- [x] Auth-gated `/cloud/findings` route
- [x] End-to-end pipeline: poll -> insert -> evaluate -> persist -> read
- [x] Code-resident detector rules (no env/DB bypass)
- [x] No false positives on benign events
- [x] @decision annotations for significant decisions
- [x] All tests pass

Closes #55