### PR TITLE
feat(#57): lookup_cloud_identity 9th orchestrator tool (REQ-P0-P5-007)

### DIFF
--- a/agent/models.py
+++ b/agent/models.py
@@ -2134,3 +2134,63 @@ def get_cloud_finding(
         "SELECT * FROM cloud_audit_findings WHERE id = ?",
         (finding_id,),
     ).fetchone()
+
+
+# ---------------------------------------------------------------------------
+# CloudTrail principal lookup — Phase 5 Wave B1 (REQ-P0-P5-007)
+# ---------------------------------------------------------------------------
+
+
+def get_cloudtrail_events_by_principal_since(
+    conn: sqlite3.Connection,
+    principal_arn: str,
+    since_ts: str,
+    limit: int = 50,
+) -> list[dict]:
+    """Return up to ``limit`` recent CloudTrail alerts for the given principal ARN.
+
+    The principal ARN is stored inside the ``raw_json`` column of
+    ``alert_details`` (the full CloudTrail event JSON, including
+    ``userIdentity.arn``).  We extract it via SQLite's ``json_extract()``
+    rather than adding a dedicated column to the shared ``alerts`` table —
+    consistent with DEC-CLOUD-003 / DEC-CLUSTER-002: source-specific fields
+    stay out of the shared schema.  The query cost is acceptable because
+    this is only called during operator-initiated triage (not in a tight loop).
+
+    Args:
+        conn:          Open SQLite connection.
+        principal_arn: Full AWS principal ARN, e.g.
+                       ``arn:aws:iam::123456789012:user/alice``.
+                       Caller is responsible for sanitizing this value before
+                       passing it here (see _handle_lookup_cloud_identity in
+                       orchestrator.py which applies sanitize_alert_field).
+        since_ts:      ISO-8601 cutoff timestamp.  Only alerts with
+                       ``ingested_at >= since_ts`` are returned.
+        limit:         Maximum rows to return (default 50).
+
+    Returns:
+        List of dicts with keys: id, rule_id, src_ip, severity, source,
+        cluster_id, ingested_at, raw_json.  Ordered newest-first.
+        Returns an empty list when no alerts match.
+    """
+    rows = conn.execute(
+        """
+        SELECT a.id,
+               a.rule_id,
+               a.src_ip,
+               a.severity,
+               a.source,
+               a.cluster_id,
+               a.ingested_at,
+               d.raw_json
+          FROM alerts a
+          JOIN alert_details d ON d.alert_id = a.id
+         WHERE a.source = 'cloudtrail'
+           AND json_extract(d.raw_json, '$.userIdentity.arn') = ?
+           AND a.ingested_at >= ?
+         ORDER BY a.ingested_at DESC
+         LIMIT ?
+        """,
+        (principal_arn, since_ts, limit),
+    ).fetchall()
+    return [dict(row) for row in rows]

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -138,6 +138,7 @@ from typing import Any, Callable, Optional
 
 from .models import (
     get_alerts_by_src_ip,
+    get_cloudtrail_events_by_principal_since,
     get_cluster,
     get_cluster_with_alerts,
     get_recent_deploys,
@@ -652,7 +653,118 @@ def _handle_check_threat_intel(tool_input: dict, conn: sqlite3.Connection) -> st
     return json.dumps(result, default=str)
 
 
-# Register the three read tools (DEC-ORCH-006, DEC-ORCH-007).
+def _handle_lookup_cloud_identity(
+    tool_input: dict, conn: sqlite3.Connection
+) -> str:
+    """Return aggregated CloudTrail context for an AWS principal ARN.
+
+    Queries the shared alerts table (source='cloudtrail') for all events
+    attributed to the given principal within a lookback window, then
+    aggregates source IPs, event names, first/last seen timestamps, and
+    total event count.  Read-only — does NOT mutate any table.
+
+    Sanitizes ``principal_arn`` via sanitize_alert_field (DEC-ORCH-004) before
+    the DB query: the ARN originates from Claude's tool-use input which may
+    ultimately derive from attacker-influenced alert metadata.
+
+    Clamps ``lookback_hours`` to [1, 168] — 1 h minimum prevents zero/negative
+    windows; 168 h (7 days) caps the scan to a reasonable recent-history window.
+
+    @decision DEC-CLOUD-007
+    @title lookup_cloud_identity is the 9th tool — registered via register_tool() (REQ-P0-P5-007)
+    @status accepted
+    @rationale Phase 5 Wave B1 adds CloudTrail principal enrichment to the
+               orchestrator reasoning loop. The handler is read-only (no INSERT/
+               UPDATE anywhere), sanitizes the principal_arn input per DEC-ORCH-004,
+               and scopes the lookback window to [1, 168] hours. Registration via
+               register_tool() follows DEC-ORCH-006 — no direct mutation of _REGISTRY
+               or TOOLS. After this registration len(TOOLS) == 9.
+
+    Args:
+        tool_input: Dict with keys ``principal_arn`` (str, required) and
+                    ``lookback_hours`` (int, optional, default 24).
+        conn:       Open SQLite connection (injected by dispatch()).
+
+    Returns:
+        JSON string with aggregated context or an empty-result shape when
+        no events are found.
+    """
+    from datetime import datetime, timezone, timedelta
+
+    raw_arn = tool_input.get("principal_arn", "")
+    # Sanitize per DEC-ORCH-004 — strips ANSI escapes, control bytes, truncates.
+    safe_arn = sanitize_alert_field(raw_arn)
+    if not safe_arn:
+        return json.dumps({"error": "principal_arn is required", "matches": 0, "context": None})
+
+    # Clamp lookback_hours to [1, 168].
+    raw_hours = tool_input.get("lookback_hours", 24)
+    try:
+        hours = int(raw_hours)
+    except (TypeError, ValueError):
+        hours = 24
+    hours = max(1, min(168, hours))
+
+    # Compute ISO-8601 cutoff timestamp in UTC.
+    cutoff_dt = datetime.now(timezone.utc) - timedelta(hours=hours)
+    since_ts = cutoff_dt.isoformat()
+
+    rows = get_cloudtrail_events_by_principal_since(conn, safe_arn, since_ts, limit=50)
+
+    if not rows:
+        log.debug("lookup_cloud_identity: no events for principal=%r", safe_arn)
+        return json.dumps({"matches": 0, "context": None})
+
+    # Aggregate across returned rows.
+    src_ips: list[str] = []
+    event_names: list[str] = []
+    seen_src_ips: set[str] = set()
+    seen_event_names: set[str] = set()
+    ingested_ats: list[str] = []
+
+    for row in rows:
+        src_ip = row.get("src_ip") or ""
+        if src_ip and src_ip not in seen_src_ips:
+            seen_src_ips.add(src_ip)
+            src_ips.append(src_ip)
+
+        # rule_id format: cloudtrail:{eventSource}:{eventName} — extract event name.
+        rule_id = row.get("rule_id", "")
+        parts = rule_id.split(":")
+        event_name = parts[-1] if len(parts) >= 3 else rule_id
+        if event_name and event_name not in seen_event_names:
+            seen_event_names.add(event_name)
+            event_names.append(event_name)
+
+        ts = row.get("ingested_at", "")
+        if ts:
+            ingested_ats.append(ts)
+
+    ingested_ats_sorted = sorted(ingested_ats)
+    first_seen_at = ingested_ats_sorted[0] if ingested_ats_sorted else None
+    last_seen_at = ingested_ats_sorted[-1] if ingested_ats_sorted else None
+
+    context = {
+        "principal_arn": safe_arn,
+        "lookback_hours": hours,
+        "total_events": len(rows),
+        "src_ips": src_ips,
+        "event_names": event_names,
+        "first_seen_at": first_seen_at,
+        "last_seen_at": last_seen_at,
+    }
+
+    log.debug(
+        "lookup_cloud_identity: principal=%r events=%d src_ips=%d",
+        safe_arn,
+        len(rows),
+        len(src_ips),
+    )
+    return json.dumps({"matches": len(rows), "context": context}, default=str)
+
+
+# Register the four read tools (DEC-ORCH-006, DEC-ORCH-007, DEC-CLOUD-007).
+# Each requires a DB connection; dispatch() injects it at call time.
 # Each requires a DB connection; dispatch() injects it at call time.
 register_tool(
     spec={
@@ -728,6 +840,39 @@ register_tool(
         },
     },
     handler=_handle_check_threat_intel,
+    requires_conn=True,
+    kind="read",
+)
+
+register_tool(
+    spec={
+        "name": "lookup_cloud_identity",
+        "description": (
+            "Look up recent CloudTrail activity for an AWS principal (IAM user, role, or root). "
+            "Use during triage to enrich an alert with the principal's recent context: "
+            "source IPs, API calls, last-seen timestamp, and total recent activity. Read-only."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "principal_arn": {
+                    "type": "string",
+                    "description": (
+                        "Full AWS principal ARN, e.g. "
+                        "arn:aws:iam::123456789012:user/alice or "
+                        "arn:aws:iam::123456789012:root"
+                    ),
+                },
+                "lookback_hours": {
+                    "type": "integer",
+                    "description": "How far back to look (default 24, max 168)",
+                    "default": 24,
+                },
+            },
+            "required": ["principal_arn"],
+        },
+    },
+    handler=_handle_lookup_cloud_identity,
     requires_conn=True,
     kind="read",
 )

--- a/tests/test_lookup_cloud_identity.py
+++ b/tests/test_lookup_cloud_identity.py
@@ -1,0 +1,467 @@
+"""
+Tests for the lookup_cloud_identity 9th orchestrator tool (Phase 5 Wave B1, REQ-P0-P5-007).
+
+Acceptance criteria verified here:
+  1. len(TOOLS) == 9, lookup_cloud_identity present with correct schema
+  2. Handler returns empty-result shape when no events exist
+  3. Handler aggregates events for the correct principal only
+  4. Handler respects lookback_hours window
+  5. Handler clamps lookback_hours to max 168
+  6. Handler clamps lookback_hours to min 1 (zero/negative → 1)
+  7. Handler sanitizes principal_arn (ANSI/control bytes stripped)
+  8. Handler caps result at 50 events regardless of DB size
+  9. Orchestrator loop calls lookup_cloud_identity and passes result to finalize_triage
+
+@decision DEC-CLOUD-007
+@title lookup_cloud_identity orchestrator tool tests — mock client + real DB
+@status accepted
+@rationale Follows the pattern in test_orchestrator_threat_intel.py (Phase 3 #35).
+           The Anthropic client is mocked (external HTTP boundary per Sacred Practice #5);
+           the SQLite DB is a real in-memory DB via init_db(":memory:").  No internal
+           module is mocked — handler, models, and dispatch() are all exercised directly.
+
+@mock-exempt: claude_client is the Anthropic HTTP API — an external boundary.
+"""
+
+import json
+import sqlite3
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.models import init_db, insert_cloudtrail_alert
+from agent.orchestrator import (
+    TOOLS,
+    _handle_lookup_cloud_identity,
+    dispatch,
+    run_triage_loop,
+)
+from agent.sources.cloudtrail import parse_cloudtrail_event
+from agent.triage import TriageResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cloudtrail_event(
+    arn: str,
+    src_ip: str = "198.51.100.1",
+    event_name: str = "DescribeInstances",
+    event_source: str = "ec2.amazonaws.com",
+    event_time: str = "2026-04-25T05:00:00Z",
+) -> dict:
+    """Build a minimal CloudTrail event dict for a given principal ARN."""
+    return {
+        "eventName": event_name,
+        "eventSource": event_source,
+        "eventTime": event_time,
+        "sourceIPAddress": src_ip,
+        "userIdentity": {
+            "type": "IAMUser",
+            "arn": arn,
+            "userName": arn.split("/")[-1] if "/" in arn else "root",
+        },
+    }
+
+
+def _seed_event(conn: sqlite3.Connection, arn: str, **kwargs) -> str:
+    """Parse and insert a single CloudTrail event; return the alert_id.
+
+    When ``event_time`` is provided in kwargs it is used both as the CloudTrail
+    eventTime AND as the explicit ``ingested_at`` value so time-windowing tests
+    can control the apparent ingestion time.  Without this, SQLite sets
+    ``ingested_at = CURRENT_TIMESTAMP`` (insertion time) regardless of the
+    event's own eventTime — which would make lookback tests non-deterministic.
+    """
+    import hashlib
+    import uuid as _uuid
+
+    event_time = kwargs.get("event_time", "2026-04-25T05:00:00Z")
+    event = _make_cloudtrail_event(arn, **kwargs)
+    parsed = parse_cloudtrail_event(event)
+
+    raw = parsed.get("raw_json", "")
+    alert_id = str(_uuid.UUID(hashlib.md5(raw.encode(), usedforsecurity=False).hexdigest()))
+
+    # Insert with explicit ingested_at so the time-window queries work correctly.
+    # ingested_at uses the same ISO-8601 string as the event_time parameter so
+    # tests that seed events "N hours ago" get rows that the handler's cutoff
+    # comparison will correctly include or exclude.
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO alerts
+            (id, rule_id, src_ip, severity, cluster_id, source,
+             dest_ip, protocol, normalized_severity, ingested_at)
+        VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)
+        """,
+        (
+            alert_id,
+            parsed.get("rule_id", "cloudtrail:unknown:unknown"),
+            parsed.get("src_ip", "unknown"),
+            parsed.get("severity", 5),
+            "cloudtrail",
+            parsed.get("dest_ip"),
+            parsed.get("protocol", "https"),
+            parsed.get("normalized_severity", "Low"),
+            event_time,
+        ),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO alert_details (alert_id, raw_json) VALUES (?, ?)",
+        (alert_id, raw),
+    )
+    conn.commit()
+    return alert_id
+
+
+def _make_config(max_calls: int = 5, wall_timeout: float = 10.0):
+    return SimpleNamespace(
+        orch_max_tool_calls=max_calls,
+        orch_wall_timeout_seconds=wall_timeout,
+        claude_model="claude-opus-4-5",
+    )
+
+
+def _make_cluster(cluster_id: str = "cluster-ci-001") -> dict:
+    return {
+        "cluster_id": cluster_id,
+        "src_ip": "198.51.100.10",
+        "rule_id": "cloudtrail:iam.amazonaws.com:CreateUser",
+        "alert_count": 1,
+        "window_start": "2026-04-25T05:00:00Z",
+        "window_end": "2026-04-25T05:05:00Z",
+        "sample_alerts": [],
+    }
+
+
+def _tool_use_response(tool_name: str, tool_input: dict, tool_id: str = "tu_001") -> MagicMock:
+    block = SimpleNamespace(
+        type="tool_use",
+        id=tool_id,
+        name=tool_name,
+        input=tool_input,
+    )
+    resp = MagicMock()
+    resp.stop_reason = "tool_use"
+    resp.content = [block]
+    return resp
+
+
+def _make_mock_client(responses: list) -> MagicMock:
+    client = MagicMock()
+    client.messages.create = MagicMock(side_effect=responses)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Test 1: TOOLS list has 9 entries; lookup_cloud_identity schema is correct
+# ---------------------------------------------------------------------------
+
+def test_lookup_cloud_identity_tool_registered():
+    """TOOLS must have exactly 9 entries; lookup_cloud_identity must be present with correct schema."""
+    assert len(TOOLS) == 9, f"Expected 9 tools, got {len(TOOLS)}: {[t['name'] for t in TOOLS]}"
+
+    names = {t["name"] for t in TOOLS}
+    assert "lookup_cloud_identity" in names, f"lookup_cloud_identity missing from TOOLS: {names}"
+
+    tool = next(t for t in TOOLS if t["name"] == "lookup_cloud_identity")
+    schema = tool["input_schema"]
+    assert schema["type"] == "object"
+    assert "principal_arn" in schema["properties"]
+    assert "principal_arn" in schema["required"]
+    assert "lookback_hours" in schema["properties"]
+    # lookback_hours is optional (not in required)
+    assert "lookback_hours" not in schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# Test 2: empty DB → empty-result shape
+# ---------------------------------------------------------------------------
+
+def test_handler_returns_empty_when_no_events():
+    """Fresh DB with no CloudTrail events returns the empty-result shape."""
+    conn = init_db(":memory:")
+
+    result_str = _handle_lookup_cloud_identity(
+        {"principal_arn": "arn:aws:iam::123:user/alice"},
+        conn,
+    )
+    result = json.loads(result_str)
+
+    assert result["matches"] == 0
+    assert result["context"] is None
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: aggregation returns correct principal's events only
+# ---------------------------------------------------------------------------
+
+def test_handler_aggregates_events_for_principal():
+    """Seeding 3 events for alice and 2 for bob → query alice returns 3, with alice's IPs only."""
+    conn = init_db(":memory:")
+
+    alice = "arn:aws:iam::123:user/alice"
+    bob = "arn:aws:iam::123:user/bob"
+
+    _seed_event(conn, alice, src_ip="10.0.0.1", event_name="DescribeInstances", event_time="2026-04-25T01:00:00Z")
+    _seed_event(conn, alice, src_ip="10.0.0.2", event_name="ListBuckets",        event_time="2026-04-25T02:00:00Z")
+    _seed_event(conn, alice, src_ip="10.0.0.3", event_name="GetObject",          event_time="2026-04-25T03:00:00Z")
+    _seed_event(conn, bob,   src_ip="10.1.0.1", event_name="CreateUser",         event_time="2026-04-25T01:30:00Z")
+    _seed_event(conn, bob,   src_ip="10.1.0.2", event_name="DeleteUser",         event_time="2026-04-25T02:30:00Z")
+
+    result_str = _handle_lookup_cloud_identity(
+        {"principal_arn": alice, "lookback_hours": 168},
+        conn,
+    )
+    result = json.loads(result_str)
+
+    assert result["matches"] == 3
+    ctx = result["context"]
+    assert ctx is not None
+    assert ctx["total_events"] == 3
+    assert ctx["principal_arn"] == alice
+
+    # All three of alice's IPs present, none of bob's
+    assert set(ctx["src_ips"]) == {"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+    assert "10.1.0.1" not in ctx["src_ips"]
+    assert "10.1.0.2" not in ctx["src_ips"]
+
+    # event_names contains alice's events
+    assert "DescribeInstances" in ctx["event_names"]
+    assert "ListBuckets" in ctx["event_names"]
+    assert "GetObject" in ctx["event_names"]
+    # bob's events not present
+    assert "CreateUser" not in ctx["event_names"]
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: lookback_hours filters correctly
+# ---------------------------------------------------------------------------
+
+def test_handler_respects_lookback_hours():
+    """Event 12h ago included in lookback=24; event 36h ago excluded. lookback=72 includes both."""
+    conn = init_db(":memory:")
+    alice = "arn:aws:iam::123:user/alice"
+
+    now = datetime.now(timezone.utc)
+    ts_recent = (now - timedelta(hours=12)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    ts_old    = (now - timedelta(hours=36)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    _seed_event(conn, alice, event_time=ts_recent, src_ip="10.0.0.1", event_name="DescribeInstances")
+    _seed_event(conn, alice, event_time=ts_old,    src_ip="10.0.0.2", event_name="ListBuckets")
+
+    # lookback=24 → only the recent event (12h ago)
+    result_24 = json.loads(_handle_lookup_cloud_identity(
+        {"principal_arn": alice, "lookback_hours": 24},
+        conn,
+    ))
+    assert result_24["matches"] == 1
+
+    # lookback=72 → both events (12h and 36h ago)
+    result_72 = json.loads(_handle_lookup_cloud_identity(
+        {"principal_arn": alice, "lookback_hours": 72},
+        conn,
+    ))
+    assert result_72["matches"] == 2
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: lookback_hours clamped to 168 max
+# ---------------------------------------------------------------------------
+
+def test_handler_clamps_lookback_to_168():
+    """lookback_hours=999 is clamped to 168; a 200h-old event is NOT returned."""
+    conn = init_db(":memory:")
+    alice = "arn:aws:iam::123:user/alice"
+
+    now = datetime.now(timezone.utc)
+    # Event 150h ago — within 168h window, should appear
+    ts_within  = (now - timedelta(hours=150)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Event 200h ago — outside 168h clamp
+    ts_outside = (now - timedelta(hours=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    _seed_event(conn, alice, event_time=ts_within,  src_ip="10.0.0.1", event_name="DescribeInstances")
+    _seed_event(conn, alice, event_time=ts_outside, src_ip="10.0.0.2", event_name="ListBuckets")
+
+    result = json.loads(_handle_lookup_cloud_identity(
+        {"principal_arn": alice, "lookback_hours": 999},
+        conn,
+    ))
+    # Clamped to 168 → only the 150h-old event is within window
+    assert result["matches"] == 1
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: lookback_hours clamped to 1 min (zero / negative)
+# ---------------------------------------------------------------------------
+
+def test_handler_clamps_lookback_to_1():
+    """lookback_hours=0 and lookback_hours=-5 are both clamped to 1."""
+    conn = init_db(":memory:")
+    alice = "arn:aws:iam::123:user/alice"
+
+    now = datetime.now(timezone.utc)
+    # Event 30 minutes ago — within 1h window
+    ts_30m = (now - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Event 2h ago — outside even the clamped 1h window
+    ts_2h  = (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    _seed_event(conn, alice, event_time=ts_30m, src_ip="10.0.0.1", event_name="DescribeInstances")
+    _seed_event(conn, alice, event_time=ts_2h,  src_ip="10.0.0.2", event_name="ListBuckets")
+
+    for bad_hours in [0, -5, -100]:
+        result = json.loads(_handle_lookup_cloud_identity(
+            {"principal_arn": alice, "lookback_hours": bad_hours},
+            conn,
+        ))
+        # Clamped to 1h → only the 30-min-old event is within the window
+        assert result["matches"] == 1, (
+            f"Expected 1 match for lookback_hours={bad_hours} (clamped to 1), "
+            f"got {result['matches']}"
+        )
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: principal_arn is sanitized (ANSI/control bytes stripped)
+# ---------------------------------------------------------------------------
+
+def test_handler_sanitizes_principal_arn():
+    """ANSI escape sequences and control bytes in principal_arn are stripped before DB query."""
+    conn = init_db(":memory:")
+    alice = "arn:aws:iam::123:user/alice"
+
+    _seed_event(conn, alice, src_ip="10.0.0.1")
+
+    # Inject ANSI escape + null byte around the valid ARN
+    dirty_arn = f"\x1b[31m{alice}\x00\x1b[0m"
+
+    result_str = _handle_lookup_cloud_identity(
+        {"principal_arn": dirty_arn, "lookback_hours": 168},
+        conn,
+    )
+    result = json.loads(result_str)
+
+    # After sanitization the ANSI escapes are stripped; the core ARN remains
+    # and the query must not crash. Shape must be valid.
+    assert "matches" in result
+    # The context may or may not match depending on truncation — key assertion
+    # is no exception and a valid JSON response.
+    if result["matches"] > 0:
+        assert result["context"] is not None
+        assert "principal_arn" in result["context"]
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: result capped at 50 events
+# ---------------------------------------------------------------------------
+
+def test_handler_limits_to_50_events():
+    """Seeding 60 events for alice → handler returns at most 50."""
+    conn = init_db(":memory:")
+    alice = "arn:aws:iam::123:user/alice"
+
+    now = datetime.now(timezone.utc)
+    for i in range(60):
+        ts = (now - timedelta(minutes=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        _seed_event(
+            conn, alice,
+            event_time=ts,
+            src_ip=f"10.0.{i // 256}.{i % 256}",
+            event_name=f"Action{i}",
+        )
+
+    result = json.loads(_handle_lookup_cloud_identity(
+        {"principal_arn": alice, "lookback_hours": 168},
+        conn,
+    ))
+
+    assert result["matches"] == 50, (
+        f"Expected 50 (DB limit), got {result['matches']}"
+    )
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 9: orchestrator loop calls lookup_cloud_identity and passes context
+#         to finalize_triage
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_loop_uses_lookup_cloud_identity():
+    """Tool-use loop dispatches lookup_cloud_identity, receives context, then finalizes."""
+    conn = init_db(":memory:")
+    alice = "arn:aws:iam::123:user/alice"
+
+    # Seed two events for alice so the tool returns real data
+    _seed_event(conn, alice, src_ip="198.51.100.10", event_name="CreateUser")
+    _seed_event(conn, alice, src_ip="198.51.100.11", event_name="AttachUserPolicy")
+
+    responses = [
+        # Turn 1: Claude calls lookup_cloud_identity
+        _tool_use_response(
+            "lookup_cloud_identity",
+            {"principal_arn": alice, "lookback_hours": 168},
+            tool_id="tu_001",
+        ),
+        # Turn 2: Claude finalizes after seeing the principal context
+        _tool_use_response(
+            "finalize_triage",
+            {
+                "severity": "High",
+                "analysis": (
+                    f"Principal {alice} performed CreateUser and AttachUserPolicy — "
+                    "privilege escalation pattern detected."
+                ),
+                "rule_ids": [],
+                "confidence": 0.88,
+            },
+            tool_id="tu_002",
+        ),
+    ]
+
+    client = _make_mock_client(responses)
+    config = _make_config()
+    cluster = _make_cluster()
+
+    result = run_triage_loop(cluster, client, config, conn=conn)
+
+    assert isinstance(result, TriageResult)
+    assert result.severity == "High"
+    # Claude was called exactly twice
+    assert client.messages.create.call_count == 2
+
+    # Verify lookup_cloud_identity appeared in the conversation transcript:
+    # The second call to messages.create must include a tool_result block
+    # for the lookup_cloud_identity invocation.
+    second_call_args = client.messages.create.call_args_list[1]
+    messages_sent = second_call_args[1].get("messages") or second_call_args[0][0]
+    # The last user message should contain the tool_result for tu_001
+    tool_result_messages = [
+        m for m in messages_sent
+        if m.get("role") == "user"
+        and isinstance(m.get("content"), list)
+        and any(
+            isinstance(blk, dict) and blk.get("type") == "tool_result"
+            for blk in m["content"]
+        )
+    ]
+    assert len(tool_result_messages) >= 1, (
+        "Expected at least one tool_result message in transcript after lookup_cloud_identity"
+    )
+
+    conn.close()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -147,7 +147,8 @@ def test_tool_schema_valid():
     """Every entry in TOOLS has the required keys and a valid input_schema."""
     # Phase 3 added check_threat_intel as the 7th tool (DEC-ORCH-005).
     # Phase 4 Wave B added recommend_attack as the 8th tool (REQ-P0-P4-001).
-    assert len(TOOLS) == 8, f"Expected 8 tools, got {len(TOOLS)}"
+    # Phase 5 Wave B1 added lookup_cloud_identity as the 9th tool (REQ-P0-P5-007).
+    assert len(TOOLS) == 9, f"Expected 9 tools, got {len(TOOLS)}"
 
     required_names = {
         "get_cluster_context",
@@ -156,8 +157,9 @@ def test_tool_schema_valid():
         "write_sigma_rule",
         "recommend_deploy",
         "finalize_triage",
-        "check_threat_intel",   # Phase 3, REQ-P0-P3-005
-        "recommend_attack",     # Phase 4 Wave B, REQ-P0-P4-001
+        "check_threat_intel",       # Phase 3, REQ-P0-P3-005
+        "recommend_attack",         # Phase 4 Wave B, REQ-P0-P4-001
+        "lookup_cloud_identity",    # Phase 5 Wave B1, REQ-P0-P5-007
     }
     found_names = {t["name"] for t in TOOLS}
     assert found_names == required_names, f"Tool name mismatch: {found_names}"

--- a/tests/test_orchestrator_threat_intel.py
+++ b/tests/test_orchestrator_threat_intel.py
@@ -106,9 +106,10 @@ def _make_mock_client(responses: list) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 def test_tool_schema_has_7_tools():
-    """TOOLS list must contain exactly 8 tools after Phase 4 Wave B addition."""
+    """TOOLS list must contain exactly 9 tools after Phase 5 Wave B1 addition."""
     # Phase 4 Wave B (REQ-P0-P4-001) added recommend_attack as the 8th tool.
-    assert len(TOOLS) == 8, f"Expected 8 tools, got {len(TOOLS)}: {[t['name'] for t in TOOLS]}"
+    # Phase 5 Wave B1 (REQ-P0-P5-007) added lookup_cloud_identity as the 9th tool.
+    assert len(TOOLS) == 9, f"Expected 9 tools, got {len(TOOLS)}: {[t['name'] for t in TOOLS]}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recommend_attack.py
+++ b/tests/test_recommend_attack.py
@@ -81,8 +81,8 @@ def test_recommend_attack_tool_registered():
 
     The 8th entry must be recommend_attack (issue #45 acceptance criterion).
     """
-    assert len(TOOLS) == 8, (
-        f"Expected 8 registered tools, got {len(TOOLS)}. "
+    assert len(TOOLS) == 9, (
+        f"Expected 9 registered tools, got {len(TOOLS)}. "
         f"Tool names: {[t['name'] for t in TOOLS]}"
     )
     tool_names = [t["name"] for t in TOOLS]


### PR DESCRIPTION
## Summary

Phase 5 Wave B1 — adds `lookup_cloud_identity(principal_arn, lookback_hours)` as the 9th orchestrator tool (TOOLS=8 → 9). Aggregates CloudTrail events for a given principal ARN from the shared `alerts` table over a configurable lookback window, returning src_ips, event_names, total_events, and first/last_seen timestamps.

Closes #57.

## Safety properties

- **Read-only** — no INSERT/UPDATE/DELETE; verified via grep on the handler
- **Sanitized input** — `principal_arn` flows through `sanitize_alert_field` (Phase 2 CSO hardening) before any query
- **Lookback clamp** — `lookback_hours` clamped to `[1, 168]`; 999/0/-5 all handled cleanly
- **Read path** — `json_extract(raw_json, '$.userIdentity.arn')` against the existing `alerts` table; no new schema
- **Registration** — uses the `register_tool()` API from #42 (DEC-ORCH-006), no direct `_REGISTRY` mutation
- **System prompt** — `system=ORCHESTRATOR_SYSTEM_PROMPT` kwarg intact

## What changed

| File | Change |
|---|---|
| `agent/models.py` | `get_cloudtrail_events_by_principal_since()` helper |
| `agent/orchestrator.py` | `_handle_lookup_cloud_identity` + `register_tool()` call + DEC-CLOUD-007 annotation |
| `tests/test_lookup_cloud_identity.py` | 9 new tests |
| `tests/test_orchestrator.py` | bumped TOOLS count assertion 8 → 9 |
| `tests/test_orchestrator_threat_intel.py` | bumped TOOLS count assertion 8 → 9 |
| `tests/test_recommend_attack.py` | bumped TOOLS count assertion 8 → 9 |

## Test plan

- [x] 298 passed / 2 skipped / 0 failed (+9 new tests over Wave A2's 289)
- [x] TOOLS=9; `lookup_cloud_identity` registered correctly
- [x] Live dispatch verified: alice=3 events with 3 distinct src_ips; bob=1; nobody=empty
- [x] Lookback window respected (24h=1 event, 48h=2)
- [x] Lookback clamping (999/0/-5) all OK without exception
- [x] DEC-CLOUD-007 annotation present in handler docstring
- [x] AUTOVERIFY: CLEAN — High confidence, no caveats

Decision IDs: DEC-CLOUD-007.