### PR TITLE
feat(#70): _require_role(role) dependency + per-route role tags (REQ-P0-P6-004)

### DIFF
--- a/agent/auth.py
+++ b/agent/auth.py
@@ -78,6 +78,48 @@ log = logging.getLogger(__name__)
 VALID_ROLES: frozenset[str] = frozenset({"viewer", "operator", "admin"})
 
 # ---------------------------------------------------------------------------
+# Role hierarchy (DEC-AUTH-P6-005)
+#
+# @decision DEC-AUTH-P6-005
+# @title Ordered role tuple defines viewer < operator < admin hierarchy
+# @status accepted
+# @rationale _require_role(r) needs to answer "does user_role satisfy required_role?"
+#            An ordered tuple makes this a single index-comparison (O(1)) with
+#            no branching. Closed-default: any role not in the tuple returns
+#            False regardless of position — unknown roles never bypass auth.
+#            In single mode, LEGACY_ADMIN_USER carries role='admin' so it
+#            satisfies every role check (viewer, operator, admin) automatically,
+#            preserving Phase 1–5 backwards compatibility without special-casing.
+# ---------------------------------------------------------------------------
+
+ROLE_HIERARCHY: tuple[str, ...] = ("viewer", "operator", "admin")
+"""Ordered role tuple from least to most privileged.
+
+Index position encodes privilege: viewer=0, operator=1, admin=2.
+A user satisfies a required role iff their role's index >= the required
+role's index. Roles outside this tuple (including unknown/novel values)
+return False from role_satisfies — closed-default, no bypass via novel roles.
+"""
+
+
+def role_satisfies(user_role: str, required_role: str) -> bool:
+    """Return True iff user_role is at least required_role per ROLE_HIERARCHY.
+
+    Closed-default: roles outside ROLE_HIERARCHY return False (unknown roles
+    fail closed — no auth bypass via novel role values in the DB).
+
+    Examples:
+        role_satisfies('admin', 'viewer')   → True   (admin beats viewer)
+        role_satisfies('operator', 'admin') → False  (operator < admin)
+        role_satisfies('viewer', 'viewer')  → True   (exact match)
+        role_satisfies('hacker', 'viewer')  → False  (unknown user role)
+        role_satisfies('admin', 'hacker')   → False  (unknown required role)
+    """
+    if user_role not in ROLE_HIERARCHY or required_role not in ROLE_HIERARCHY:
+        return False
+    return ROLE_HIERARCHY.index(user_role) >= ROLE_HIERARCHY.index(required_role)
+
+# ---------------------------------------------------------------------------
 # Argon2id password hasher (DEC-AUTH-P6-001)
 #
 # argon2-cffi PasswordHasher defaults (as of 21.x):

--- a/agent/main.py
+++ b/agent/main.py
@@ -62,6 +62,34 @@ Auth:
            the same severity_min_level filter applies to both sources:
            sev 1 → 7 (Critical), sev 2 → 6 (High), sev 3 → 5 (Medium).
            Only sev 1 and 2 pass the default threshold of 7.
+
+Wave A2 additions (REQ-P0-P6-004):
+
+@decision DEC-AUTH-P6-006
+@title _require_role factory composes on _require_auth; role tags at registration time
+@status accepted
+@rationale Every auth-gated route now carries an explicit minimum role tag via
+           Depends(_require_role('viewer|operator|admin')). The factory raises
+           ValueError at import/startup for unknown role names (typos surface at
+           boot, not at first request). 401 (auth failure) always precedes 403
+           (role failure) because _require_role's inner dep is _require_auth.
+           Single-mode SHAFERHUND_TOKEN deployments are unaffected: LEGACY_ADMIN_USER
+           carries role='admin', satisfying every role check (DEC-AUTH-P6-005).
+
+Route RBAC table (Wave A2, REQ-P0-P6-004):
+  GET  /health              — public (DEC-HEALTH-002)
+  GET  /canary/hit/{token}  — public (trap endpoint)
+  GET  /metrics             — viewer
+  GET  /                    — viewer
+  GET  /deploy-events       — viewer
+  GET  /clusters/{id}       — viewer
+  GET  /recommendations     — viewer
+  GET  /cloud/findings      — viewer
+  POST /rules/{id}/deploy       — operator
+  POST /rules/{id}/undo-deploy  — operator
+  POST /canary/spawn            — operator
+  POST /posture/run             — operator
+  POST /recommendations/{id}/execute — operator
 """
 
 import asyncio
@@ -107,7 +135,7 @@ from .models import (
 from .orchestrator import get_orchestrator_stats
 from .triage import TriageResult, TriageQueue
 from . import threat_intel as _threat_intel
-from .auth import authenticate_token, LEGACY_ADMIN_USER
+from .auth import authenticate_token, LEGACY_ADMIN_USER, ROLE_HIERARCHY, role_satisfies
 from .models import count_threat_intel_records
 from . import canary as _canary
 from .canary import spawn_canary, record_hit, count_canary_triggers_since
@@ -435,6 +463,48 @@ def _require_auth(
     return user
 
 
+def _require_role(required_role: str):
+    """FastAPI dependency factory that requires the authenticated user to
+    have at least ``required_role`` per the role hierarchy.
+
+    Usage::
+
+        @app.post("/posture/run", dependencies=[Depends(_require_role("operator"))])
+
+    Closed-default: unknown user roles or unknown required_role values → 403.
+    Auth failure (missing/bad token) still returns 401 first — the inner
+    ``_require_auth`` dependency runs before the role check.
+
+    The factory raises ``ValueError`` at route-registration time if
+    ``required_role`` is not in ROLE_HIERARCHY, surfacing typos at boot
+    rather than at first request.
+
+    @decision DEC-AUTH-P6-006
+    @title _require_role factory composes on top of _require_auth; ValueError at boot for bad role names
+    @status accepted
+    @rationale Parameterised Depends factory keeps route decorators declarative
+               ("operator-required" is visible in the route signature) without
+               per-handler boilerplate. ValueError at registration time means a
+               typo like _require_role('opeator') fails during import/startup,
+               not silently at the first request that hits the bad route.
+               Unknown user roles in the DB fail closed (403) per DEC-AUTH-P6-005.
+    """
+    if required_role not in ROLE_HIERARCHY:
+        raise ValueError(
+            f"Unknown required_role: {required_role!r}; expected one of {ROLE_HIERARCHY}"
+        )
+
+    def _dep(user: dict = Depends(_require_auth)) -> dict:
+        if not role_satisfies(user.get("role", ""), required_role):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"role '{user.get('role')}' insufficient (need '{required_role}' or higher)",
+            )
+        return user
+
+    return _dep
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -597,7 +667,7 @@ def _build_cloudtrail_metrics_block(db, settings) -> dict:
     }
 
 
-@app.get("/metrics", dependencies=[Depends(_require_auth)])
+@app.get("/metrics", dependencies=[Depends(_require_role("viewer"))])
 async def metrics() -> JSONResponse:
     """Authenticated operational stats. Migration from /health per CSO F5.
 
@@ -659,7 +729,7 @@ async def metrics() -> JSONResponse:
     })
 
 
-@app.get("/", response_class=HTMLResponse, dependencies=[Depends(_require_auth)])
+@app.get("/", response_class=HTMLResponse, dependencies=[Depends(_require_role("viewer"))])
 async def index(request: Request, source: Optional[str] = None):
     """Dashboard: cluster list with HTMX auto-refresh every 10 seconds.
 
@@ -682,7 +752,7 @@ async def index(request: Request, source: Optional[str] = None):
 @app.get(
     "/deploy-events",
     response_class=HTMLResponse,
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("viewer"))],
 )
 async def deploy_events_page(request: Request, offset: int = 0):
     """Audit log page: paginated deploy events, 50 rows per page.
@@ -713,7 +783,7 @@ async def deploy_events_page(request: Request, offset: int = 0):
 @app.get(
     "/clusters/{cluster_id}",
     response_class=HTMLResponse,
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("viewer"))],
 )
 async def cluster_detail(request: Request, cluster_id: str):
     """Cluster detail: alert list, AI analysis, YARA and Sigma rules with deploy status."""
@@ -745,7 +815,7 @@ async def cluster_detail(request: Request, cluster_id: str):
 
 @app.post(
     "/rules/{rule_id}/deploy",
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("operator"))],
 )
 async def deploy_rule(rule_id: str):
     """Write a validated YARA rule to the /rules/ volume.
@@ -782,7 +852,7 @@ async def deploy_rule(rule_id: str):
 
 @app.post(
     "/rules/{rule_id}/undo-deploy",
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("operator"))],
 )
 async def undo_deploy_rule(rule_id: str):
     """Delete a deployed rule file and mark its audit row as reverted.
@@ -840,7 +910,7 @@ async def undo_deploy_rule(rule_id: str):
 
 @app.post(
     "/canary/spawn",
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("operator"))],
 )
 async def canary_spawn(request: Request) -> JSONResponse:
     """Spawn a new DNS or HTTP canary token.
@@ -936,7 +1006,7 @@ async def canary_hit(token: str, request: Request) -> JSONResponse:
 
 @app.post(
     "/posture/run",
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("operator"))],
 )
 async def posture_run() -> JSONResponse:
     """Fire an ad-hoc Atomic Red Team posture batch and return immediately.
@@ -1009,7 +1079,7 @@ async def posture_run() -> JSONResponse:
 
 @app.get(
     "/recommendations",
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("viewer"))],
 )
 async def list_recommendations() -> JSONResponse:
     """List pending attack recommendations for operator review.
@@ -1039,7 +1109,7 @@ async def list_recommendations() -> JSONResponse:
 
 @app.post(
     "/recommendations/{recommendation_id}/execute",
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("operator"))],
 )
 async def execute_recommendation_route(
     recommendation_id: int,
@@ -1119,7 +1189,7 @@ async def execute_recommendation_route(
 
 @app.get(
     "/cloud/findings",
-    dependencies=[Depends(_require_auth)],
+    dependencies=[Depends(_require_role("viewer"))],
 )
 async def list_cloud_findings_route(
     limit: int = 50,

--- a/tests/test_role_middleware.py
+++ b/tests/test_role_middleware.py
@@ -1,0 +1,332 @@
+"""
+Tests for _require_role(role) middleware — REQ-P0-P6-004.
+
+Covers:
+  - role_satisfies() hierarchy logic (DEC-AUTH-P6-005)
+  - role_satisfies() closed-default for unknown roles
+  - _require_role factory: ValueError on unknown required_role (boot-time safety)
+  - 403 when authenticated user's role is too low
+  - 200 when role is sufficient (operator on operator-required route)
+  - 200 when admin hits any role-tagged route
+  - 401 before 403: missing token → 401, not 403 (auth precedes role check)
+  - single-mode legacy SHAFERHUND_TOKEN satisfies all role checks (DEC-AUTH-P6-004)
+
+# @mock-exempt: patch.object targets _settings and _db — module-level singletons
+# in main.py populated by lifespan(). Swapping them for test-controlled objects
+# is equivalent to dependency injection, not internal mocking. auth.py logic
+# runs against a real in-memory SQLite connection.
+"""
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from agent.auth import (
+    ROLE_HIERARCHY,
+    VALID_ROLES,
+    generate_token,
+    hash_password,
+    role_satisfies,
+)
+from agent.models import init_db, insert_user, insert_user_token
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path):
+    conn = init_db(str(tmp_path / "test.db"))
+    yield conn
+    conn.close()
+
+
+def _make_user_token(db, username, role):
+    """Insert a user + token; return the raw bearer token."""
+    ph = hash_password("hunter2")
+    user_id = insert_user(db, username, ph, role)
+    raw_token, token_hash = generate_token()
+    insert_user_token(db, user_id, token_hash, f"{username}-tok")
+    return raw_token
+
+
+def _make_multi_client(db):
+    """Return a TestClient in multi-auth mode with patched singletons."""
+    import agent.main as main_mod
+    from agent.config import Settings
+
+    settings = Settings(
+        anthropic_api_key="test-key",
+        shaferhund_token="",
+        shaferhund_auth_mode="multi",
+    )
+    return patch.object(main_mod, "_settings", settings), patch.object(main_mod, "_db", db)
+
+
+# ---------------------------------------------------------------------------
+# role_satisfies() — hierarchy logic (DEC-AUTH-P6-005)
+# ---------------------------------------------------------------------------
+
+
+def test_role_satisfies_hierarchy_admin_satisfies_all():
+    """admin satisfies viewer, operator, and admin."""
+    assert role_satisfies("admin", "viewer") is True
+    assert role_satisfies("admin", "operator") is True
+    assert role_satisfies("admin", "admin") is True
+
+
+def test_role_satisfies_hierarchy_operator_satisfies_operator_and_viewer():
+    """operator satisfies operator and viewer but not admin."""
+    assert role_satisfies("operator", "viewer") is True
+    assert role_satisfies("operator", "operator") is True
+    assert role_satisfies("operator", "admin") is False
+
+
+def test_role_satisfies_hierarchy_viewer_satisfies_viewer_only():
+    """viewer satisfies only viewer."""
+    assert role_satisfies("viewer", "viewer") is True
+    assert role_satisfies("viewer", "operator") is False
+    assert role_satisfies("viewer", "admin") is False
+
+
+def test_role_satisfies_unknown_user_role_returns_false():
+    """Unknown user role (e.g. DB corruption / novel value) → False (closed-default)."""
+    assert role_satisfies("superuser", "viewer") is False
+    assert role_satisfies("hacker", "admin") is False
+    assert role_satisfies("", "viewer") is False
+
+
+def test_role_satisfies_unknown_required_role_returns_false():
+    """Unknown required_role → False (closed-default, even for admin user)."""
+    assert role_satisfies("admin", "hacker") is False
+    assert role_satisfies("admin", "") is False
+    assert role_satisfies("admin", "superadmin") is False
+
+
+def test_role_hierarchy_tuple_order():
+    """ROLE_HIERARCHY must be ordered viewer < operator < admin."""
+    assert ROLE_HIERARCHY == ("viewer", "operator", "admin")
+    assert ROLE_HIERARCHY.index("viewer") < ROLE_HIERARCHY.index("operator")
+    assert ROLE_HIERARCHY.index("operator") < ROLE_HIERARCHY.index("admin")
+
+
+def test_valid_roles_matches_hierarchy():
+    """VALID_ROLES frozenset must contain exactly the roles in ROLE_HIERARCHY."""
+    assert VALID_ROLES == frozenset(ROLE_HIERARCHY)
+
+
+# ---------------------------------------------------------------------------
+# _require_role factory — boot-time ValueError on bad role names
+# ---------------------------------------------------------------------------
+
+
+def test_require_role_factory_unknown_role_raises():
+    """_require_role('hacker') raises ValueError at factory call time."""
+    import agent.main as main_mod
+
+    with pytest.raises(ValueError, match="Unknown required_role"):
+        main_mod._require_role("hacker")
+
+
+def test_require_role_factory_all_valid_roles_do_not_raise():
+    """_require_role(r) for every valid role must not raise."""
+    import agent.main as main_mod
+
+    for role in ROLE_HIERARCHY:
+        dep = main_mod._require_role(role)
+        assert callable(dep), f"_require_role({role!r}) should return a callable"
+
+
+# ---------------------------------------------------------------------------
+# 401 before 403 — auth failure takes precedence over role failure
+# ---------------------------------------------------------------------------
+
+
+def test_require_role_401_before_403_no_token(db):
+    """No Authorization header on an operator-required route → 401, not 403."""
+    import agent.main as main_mod
+
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.post("/posture/run")
+        assert resp.status_code == 401, (
+            f"Expected 401 (auth failure before role check), got {resp.status_code}: {resp.text}"
+        )
+
+
+def test_require_role_401_before_403_bad_token(db):
+    """Invalid bearer token on an operator-required route → 401, not 403."""
+    import agent.main as main_mod
+
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.post(
+            "/posture/run",
+            headers={"Authorization": "Bearer totally-invalid-token-xyz"},
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 403 when role is insufficient
+# ---------------------------------------------------------------------------
+
+
+def test_require_role_403_viewer_on_operator_route(db):
+    """viewer token on operator-required /posture/run → 403."""
+    import agent.main as main_mod
+
+    viewer_token = _make_user_token(db, "viewer_user", "viewer")
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.post(
+            "/posture/run",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert resp.status_code == 403, (
+            f"viewer on operator route: expected 403, got {resp.status_code}: {resp.text}"
+        )
+        assert "insufficient" in resp.json().get("detail", "").lower()
+
+
+def test_require_role_403_viewer_on_execute_route(db):
+    """viewer token on operator-required /recommendations/{id}/execute → 403."""
+    import agent.main as main_mod
+
+    viewer_token = _make_user_token(db, "viewer2", "viewer")
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.post(
+            "/recommendations/999/execute",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        # 403 role failure takes precedence over 404 (not found) or 503 (db not ready)
+        assert resp.status_code == 403, (
+            f"viewer on execute route: expected 403, got {resp.status_code}: {resp.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 200 when role is sufficient
+# ---------------------------------------------------------------------------
+
+
+def test_require_role_200_operator_on_operator_route(db):
+    """operator token on operator-required /posture/run → not 401/403 (likely 503 db-not-ready or 422)."""
+    import agent.main as main_mod
+
+    operator_token = _make_user_token(db, "op_user", "operator")
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.post(
+            "/posture/run",
+            headers={"Authorization": f"Bearer {operator_token}"},
+        )
+        # Role check passes → should NOT be 401 or 403 (may be 503 if settings missing)
+        assert resp.status_code not in (401, 403), (
+            f"operator on operator route: expected role to pass, got {resp.status_code}: {resp.text}"
+        )
+
+
+def test_require_role_200_admin_on_operator_route(db):
+    """admin token on operator-required /posture/run → not 401/403."""
+    import agent.main as main_mod
+
+    admin_token = _make_user_token(db, "admin_user", "admin")
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.post(
+            "/posture/run",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code not in (401, 403), (
+            f"admin on operator route: expected role to pass, got {resp.status_code}: {resp.text}"
+        )
+
+
+def test_require_role_200_viewer_on_viewer_route(db):
+    """viewer token on viewer-required /metrics → 200."""
+    import agent.main as main_mod
+
+    viewer_token = _make_user_token(db, "viewer3", "viewer")
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.get(
+            "/metrics",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert resp.status_code == 200, (
+            f"viewer on /metrics: expected 200, got {resp.status_code}: {resp.text}"
+        )
+
+
+def test_require_role_200_admin_on_viewer_route(db):
+    """admin token on viewer-required /metrics → 200 (admin satisfies viewer)."""
+    import agent.main as main_mod
+
+    admin_token = _make_user_token(db, "admin2", "admin")
+    p_settings, p_db = _make_multi_client(db)
+    with p_settings, p_db:
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+        resp = client.get(
+            "/metrics",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200, (
+            f"admin on /metrics: expected 200, got {resp.status_code}: {resp.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Single-mode backwards compatibility (DEC-AUTH-P6-004, DEC-COMPAT-P6-001)
+# ---------------------------------------------------------------------------
+
+
+def test_single_mode_legacy_token_passes_all_role_checks(db):
+    """single mode: SHAFERHUND_TOKEN → synthetic admin → satisfies every role check.
+
+    Phase 1-5 deployments must not break when role middleware is added.
+    Tests both a viewer-required route (/metrics) and an operator-required
+    route (/posture/run) to confirm the synthetic admin clears all checks.
+    """
+    import agent.main as main_mod
+    from agent.config import Settings
+
+    settings = Settings(
+        anthropic_api_key="test-key",
+        shaferhund_token="legacy-secret",
+        shaferhund_auth_mode="single",
+    )
+    with (
+        patch.object(main_mod, "_settings", settings),
+        patch.object(main_mod, "_db", db),
+    ):
+        client = TestClient(main_mod.app, raise_server_exceptions=True)
+
+        # viewer-required route
+        resp = client.get(
+            "/metrics",
+            headers={"Authorization": "Bearer legacy-secret"},
+        )
+        assert resp.status_code == 200, (
+            f"single-mode legacy token on /metrics: expected 200, got {resp.status_code}"
+        )
+
+        # operator-required route — role check must pass even though it's "operator"
+        resp = client.post(
+            "/posture/run",
+            headers={"Authorization": "Bearer legacy-secret"},
+        )
+        assert resp.status_code not in (401, 403), (
+            f"single-mode legacy token on /posture/run: expected role to pass, "
+            f"got {resp.status_code}: {resp.text}"
+        )

--- a/tests/test_route_role_tags.py
+++ b/tests/test_route_role_tags.py
@@ -1,0 +1,306 @@
+"""
+Per-route RBAC matrix tests — REQ-P0-P6-004.
+
+For each role-tagged route, verify:
+  - insufficient role → 403
+  - sufficient role → not 401/403 (role check passes; downstream may 503/422/404)
+
+Routes covered (per Wave A2 RBAC table in main.py module docstring):
+  viewer-required:  GET /metrics, GET /recommendations, GET /cloud/findings
+  operator-required: POST /posture/run, POST /recommendations/{id}/execute,
+                     POST /canary/spawn, POST /rules/{id}/deploy,
+                     POST /rules/{id}/undo-deploy
+
+Public routes (/health, /canary/hit/{token}) are not tested here — they need
+no auth and are covered by existing test_health.py / test_canary.py.
+
+# @mock-exempt: patch.object targets _settings and _db — module-level singletons
+# in main.py. auth.py and role_satisfies() run against a real in-memory SQLite
+# connection with no mocks.
+"""
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from agent.auth import generate_token, hash_password
+from agent.models import init_db, insert_user, insert_user_token
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path):
+    conn = init_db(str(tmp_path / "test.db"))
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def tokens(db):
+    """Return {role: raw_bearer_token} for viewer, operator, admin."""
+    result = {}
+    for role in ("viewer", "operator", "admin"):
+        ph = hash_password("hunter2")
+        uid = insert_user(db, f"user_{role}", ph, role)
+        raw, h = generate_token()
+        insert_user_token(db, uid, h, f"{role}-tok")
+        result[role] = raw
+    return result
+
+
+def _multi_client(db):
+    """Context managers to patch _settings and _db for multi-auth mode."""
+    import agent.main as main_mod
+    from agent.config import Settings
+
+    settings = Settings(
+        anthropic_api_key="test-key",
+        shaferhund_token="",
+        shaferhund_auth_mode="multi",
+    )
+    return (
+        patch.object(main_mod, "_settings", settings),
+        patch.object(main_mod, "_db", db),
+    )
+
+
+def _get(client, path, token):
+    return client.get(path, headers={"Authorization": f"Bearer {token}"})
+
+
+def _post(client, path, token, json=None):
+    return client.post(path, headers={"Authorization": f"Bearer {token}"}, json=json or {})
+
+
+# ---------------------------------------------------------------------------
+# viewer-required routes
+# ---------------------------------------------------------------------------
+
+
+class TestGetMetrics:
+    def test_viewer_ok(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            assert _get(c, "/metrics", tokens["viewer"]).status_code == 200
+
+    def test_operator_ok(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            assert _get(c, "/metrics", tokens["operator"]).status_code == 200
+
+    def test_admin_ok(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            assert _get(c, "/metrics", tokens["admin"]).status_code == 200
+
+
+class TestGetRecommendations:
+    def test_viewer_ok(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _get(c, "/recommendations", tokens["viewer"])
+            assert resp.status_code == 200
+
+    def test_no_token_401(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            assert c.get("/recommendations").status_code == 401
+
+
+class TestGetCloudFindings:
+    def test_viewer_ok(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _get(c, "/cloud/findings", tokens["viewer"])
+            assert resp.status_code == 200
+
+    def test_operator_ok(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _get(c, "/cloud/findings", tokens["operator"])
+            assert resp.status_code == 200
+
+    def test_no_token_401(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            assert c.get("/cloud/findings").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# operator-required routes
+# ---------------------------------------------------------------------------
+
+
+class TestPostPostureRun:
+    def test_viewer_403(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/posture/run", tokens["viewer"])
+            assert resp.status_code == 403, (
+                f"viewer on /posture/run: expected 403, got {resp.status_code}"
+            )
+
+    def test_operator_role_passes(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/posture/run", tokens["operator"])
+            assert resp.status_code not in (401, 403), (
+                f"operator on /posture/run: expected role to pass, got {resp.status_code}"
+            )
+
+    def test_admin_role_passes(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/posture/run", tokens["admin"])
+            assert resp.status_code not in (401, 403), (
+                f"admin on /posture/run: expected role to pass, got {resp.status_code}"
+            )
+
+    def test_no_token_401(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            assert _post(c, "/posture/run", "bad-token").status_code == 401
+
+
+class TestPostRecommendationExecute:
+    """operator-required: POST /recommendations/{id}/execute"""
+
+    def test_viewer_403(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/recommendations/1/execute", tokens["viewer"])
+            assert resp.status_code == 403
+
+    def test_operator_role_passes(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/recommendations/1/execute", tokens["operator"])
+            # Role passes; 404 (rec not found) or 503 (db) is fine — not 401/403
+            assert resp.status_code not in (401, 403), (
+                f"operator on execute: expected role to pass, got {resp.status_code}"
+            )
+
+    def test_admin_role_passes(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/recommendations/1/execute", tokens["admin"])
+            assert resp.status_code not in (401, 403)
+
+
+class TestPostCanarySpawn:
+    """operator-required: POST /canary/spawn"""
+
+    def test_viewer_403(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/canary/spawn", tokens["viewer"], json={"type": "http", "name": "t"})
+            assert resp.status_code == 403
+
+    def test_operator_role_passes(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/canary/spawn", tokens["operator"], json={"type": "http", "name": "t"})
+            assert resp.status_code not in (401, 403)
+
+
+class TestPostRulesDeploy:
+    """operator-required: POST /rules/{rule_id}/deploy"""
+
+    def test_viewer_403(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/rules/nonexistent-rule/deploy", tokens["viewer"])
+            assert resp.status_code == 403
+
+    def test_operator_role_passes(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/rules/nonexistent-rule/deploy", tokens["operator"])
+            # Role passes → 404 (rule not found) is fine
+            assert resp.status_code not in (401, 403)
+
+
+class TestPostRulesUndoDeploy:
+    """operator-required: POST /rules/{rule_id}/undo-deploy"""
+
+    def test_viewer_403(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/rules/nonexistent-rule/undo-deploy", tokens["viewer"])
+            assert resp.status_code == 403
+
+    def test_operator_role_passes(self, db, tokens):
+        import agent.main as main_mod
+        p1, p2 = _multi_client(db)
+        with p1, p2:
+            c = TestClient(main_mod.app, raise_server_exceptions=True)
+            resp = _post(c, "/rules/nonexistent-rule/undo-deploy", tokens["operator"])
+            # Role passes → 404 (file not found on disk) is fine
+            assert resp.status_code not in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Public routes stay public (DEC-HEALTH-002)
+# ---------------------------------------------------------------------------
+
+
+def test_health_public_no_auth_needed(db):
+    """GET /health requires no token — always 200 regardless of auth state."""
+    import agent.main as main_mod
+    p1, p2 = _multi_client(db)
+    with p1, p2:
+        c = TestClient(main_mod.app, raise_server_exceptions=True)
+        assert c.get("/health").status_code == 200
+
+
+def test_canary_hit_public_no_auth_needed(db):
+    """GET /canary/hit/{token} requires no token — public trap endpoint."""
+    import agent.main as main_mod
+    p1, p2 = _multi_client(db)
+    with p1, p2:
+        c = TestClient(main_mod.app, raise_server_exceptions=True)
+        assert c.get("/canary/hit/sometoken").status_code == 200


### PR DESCRIPTION
## Scope

Wave A2 of Phase 6: authorization layer on top of Wave A1 authentication. Adds a closed-default role hierarchy + a `_require_role(role)` FastAPI dependency factory, and retags every protected route with its minimum required role. Phase 1-5 deployments using the legacy single-mode `SHAFERHUND_TOKEN` continue to work — that token resolves to a synthetic admin which satisfies all role checks.

Closes #70.

## Files (4)

- `agent/auth.py` — `ROLE_HIERARCHY = ('viewer', 'operator', 'admin')` + `role_satisfies()` (closed-default on unknown roles). DEC-AUTH-P6-005.
- `agent/main.py` — `_require_role(role)` factory with boot-time validation (ValueError on unknown role) and 401-before-403 ordering; 11 routes retagged. DEC-AUTH-P6-006.
- `tests/test_role_middleware.py` (new) — 18 tests
- `tests/test_route_role_tags.py` (new) — 23 tests

## Route RBAC table

| Role | Routes |
|------|--------|
| public | `/health`, `/canary/hit/{token}` |
| viewer | `/metrics`, `/`, `/deploy-events`, `/clusters/{id}`, `/recommendations`, `/cloud/findings` |
| operator | `/rules/{id}/deploy`, `/rules/{id}/undo-deploy`, `/canary/spawn`, `/posture/run`, `/recommendations/{id}/execute` |

## Safety invariants verified live

**V4 — 14-cell role enforcement matrix has no auth bypass.**
viewer token hitting an operator-required route returns 403; operator returns 200; admin returns 200. 401-before-403 ordering verified — request with no token returns 401, not 403 (auth checked before role).

**V5 — Single-mode legacy token preserves Phase 1-5 behavior.**
`SHAFERHUND_TOKEN` (legacy) returns 200 on every role-gated route. Synthetic admin satisfies all role checks. Existing deployments are not broken.

**V7 — Closed-default holds against DB corruption.**
Corrupted user row with `role='superuser'` (not in `ROLE_HIERARCHY`) returns 403 on protected routes — never 200. Unknown roles never satisfy any required role.

**V6 — Factory validates at boot, not at request time.**
`_require_role('hacker')` raises `ValueError` immediately on app construction. Typos in route decorators fail fast at startup, never silently in production.

## Tests

- 399 passed, 2 skipped, 3 deselected, 0 failed
- +41 new tests over Wave A1 (was 360)
- TOOLS still 9 (no orchestrator surface change)

## Decision annotations

- **DEC-AUTH-P6-005** — `ROLE_HIERARCHY` is a closed enum with closed-default `role_satisfies`. Unknown roles never match. Rationale: defense-in-depth against DB corruption / config drift.
- **DEC-AUTH-P6-006** — `_require_role(role)` is a factory (not a decorator) that returns a per-role FastAPI dependency. Validates the role argument at construction time. 401-before-403 ordering enforced by structuring auth-then-role inside the dependency. Rationale: composable with existing `_require_auth` dependency, fail-fast on typos.

## Tester report

`/home/j/projects/shaferhund/.worktrees/feature-phase6-role-middleware/tmp/verification-issue-70.md` — AUTOVERIFY: CLEAN, High confidence, full coverage, no caveats.

Closes #70