### PR TITLE
feat(#72): rule_tags table + scoped fleet manifest with HMAC signing (REQ-P0-P6-001)

### DIFF
--- a/agent/fleet.py
+++ b/agent/fleet.py
@@ -1,0 +1,253 @@
+"""
+Shaferhund Phase 6 Wave A4 — Fleet manifest server.
+
+Builds HMAC-signed rule manifests scoped by tag.  The manifest is consumed
+by the fleet agent (Wave B2, REQ-P0-P6-002) which verifies the signature
+before applying rules to the local Wazuh agent's rules directory.
+
+Design decisions:
+
+@decision DEC-FLEET-P6-001
+@title HMAC-signed manifests over per-agent shared secret; real crypto signing is Phase 7
+@status accepted
+@rationale HMAC over the manifest body (using the same SHAFERHUND_AUDIT_KEY
+           as the audit chain — DEC-AUDIT-P6-001) provides integrity +
+           authenticity given a pre-shared secret. This is the relevant
+           property for a manager-pushes-to-known-agent model. Real
+           cryptographic signing (cosign/minisign) is REQ-NOGO-P6-007 /
+           REQ-P2-P6-002 — a worthwhile follow-up once the contract is
+           operational. HMAC cost is one SHA-256 computation per manifest
+           fetch — negligible. The key reuses SHAFERHUND_AUDIT_KEY (one key,
+           two uses in Phase 6) as specified; a separate fleet key is a
+           Phase 7 addition if operational signal demands it.
+
+@decision DEC-FLEET-P6-002
+@title Only deployed=1 rules appear in fleet manifests; draft/pending rules never leak
+@status accepted
+@rationale Rule content may be partially written or untested while deployed=0.
+           Leaking draft YARA/Sigma rule content to fleet agents would expose
+           internal detection logic before it is ready. The manifest builder
+           passes deployed_only=True to list_rules_for_tag so the schema-level
+           deployed flag is the gate — there is no second application-level
+           check to drift from. Operators must explicitly deploy (POST
+           /rules/{id}/deploy) before a rule appears in any manifest.
+
+Canonical manifest body encoding:
+
+The body fields are encoded as a UTF-8 JSON array in fixed field order:
+
+    [version, tag, generated_at, rules]
+
+where ``rules`` is a list of rule dicts each containing:
+
+    {id, rule_type, name, content, syntax_valid}
+
+Using a positional JSON array (not a dict) guarantees that field order is
+part of the canonical encoding — any re-ordering of the top-level fields
+produces different bytes.  This is the same strategy as agent/audit.py's
+canonical_row encoding (DEC-AUDIT-P6-001).
+
+The ``manifest_id`` and ``signature`` fields are NOT part of the canonical
+body so they can be computed from it without circularity.  ``manifest_id``
+is the SHA-256 hex of the canonical bytes (content-addressing).
+
+HMAC computation:
+
+    signature = HMAC-SHA256(key_bytes, canonical_bytes).hexdigest()
+
+Same primitive as ``compute_row_hmac`` in agent/audit.py.
+"""
+
+import hashlib
+import hmac as _hmac
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from typing import Optional
+
+from .models import list_rules_for_tag
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Canonical body encoding (DEC-FLEET-P6-001)
+# ---------------------------------------------------------------------------
+
+
+def canonical_manifest_body(
+    version: int,
+    tag: str,
+    generated_at: str,
+    rules: list[dict],
+) -> bytes:
+    """Return the deterministic canonical bytes for signing.
+
+    Encodes the four body fields in fixed order as a UTF-8 JSON array:
+
+        [version, tag, generated_at, rules]
+
+    The ``rules`` list must already be in the stable order (e.g. sorted by
+    rule id or created_at) that ``build_manifest`` produces — callers should
+    not re-order after this call.
+
+    The encoding is identical in spirit to ``canonical_row`` in audit.py:
+    a positional JSON array with ``separators=(',', ':')`` and
+    ``ensure_ascii=False`` so the result is compact and unambiguous.
+
+    Args:
+        version:      Integer manifest version (currently 1).
+        tag:          Scoping tag string (e.g. 'group:web').
+        generated_at: ISO-8601 UTC timestamp string.
+        rules:        List of rule dicts (keys: id, rule_type, name, content,
+                      syntax_valid).  Field order within each rule dict is
+                      preserved as passed.
+
+    Returns:
+        UTF-8-encoded JSON bytes.  Same inputs always produce same bytes.
+    """
+    payload = [version, tag, generated_at, rules]
+    return json.dumps(
+        payload,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# HMAC signing and verification (DEC-FLEET-P6-001)
+# ---------------------------------------------------------------------------
+
+
+def sign_manifest(key: bytes, canonical: bytes) -> str:
+    """Compute HMAC-SHA256 over canonical manifest bytes.
+
+    Returns a lowercase hex string (64 characters).  Same primitive as
+    ``compute_row_hmac`` in agent/audit.py — one HMAC function, two uses.
+
+    Args:
+        key:       Raw key bytes (from SHAFERHUND_AUDIT_KEY hex-decoded).
+        canonical: Output of ``canonical_manifest_body()``.
+
+    Returns:
+        Hex digest string, e.g. ``'a3f1...9b2d'``.
+    """
+    return _hmac.new(key, canonical, hashlib.sha256).hexdigest()
+
+
+def verify_manifest(manifest: dict, key: bytes) -> bool:
+    """Verify a manifest's HMAC signature against the provided key.
+
+    Re-derives the canonical bytes from the manifest's body fields and
+    computes the expected HMAC.  Uses ``hmac.compare_digest`` for
+    constant-time comparison to prevent timing side-channels.
+
+    Args:
+        manifest: Full manifest dict as returned by ``build_manifest()``.
+                  Must contain keys: version, tag, generated_at, rules,
+                  signature.
+        key:      Raw key bytes to verify against.
+
+    Returns:
+        True if the signature is valid; False if tampered or wrong key.
+        Never raises — callers can treat the bool directly.
+    """
+    try:
+        version = manifest["version"]
+        tag = manifest["tag"]
+        generated_at = manifest["generated_at"]
+        rules = manifest["rules"]
+        stored_sig = manifest["signature"]
+    except (KeyError, TypeError):
+        log.debug("verify_manifest: missing required field in manifest")
+        return False
+
+    try:
+        canon = canonical_manifest_body(version, tag, generated_at, rules)
+        expected = sign_manifest(key, canon)
+        return _hmac.compare_digest(expected, stored_sig)
+    except Exception:
+        log.debug("verify_manifest: exception during recomputation", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Manifest builder (DEC-FLEET-P6-001, DEC-FLEET-P6-002)
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(
+    conn: sqlite3.Connection,
+    tag: str,
+    key: bytes,
+    generated_at: Optional[str] = None,
+) -> dict:
+    """Build a signed rule manifest for all deployed rules carrying *tag*.
+
+    Queries the DB for deployed rules with this tag (deployed_only=True per
+    DEC-FLEET-P6-002), encodes the canonical body, computes the HMAC
+    signature and SHA-256 manifest_id, and returns the full manifest dict.
+
+    The returned dict has this shape::
+
+        {
+            "version":      1,
+            "manifest_id":  "<sha256hex of canonical body>",
+            "tag":          "group:web",
+            "generated_at": "2026-04-25T16:30:00+00:00",
+            "rules": [
+                {
+                    "id":           "<rule UUID>",
+                    "rule_type":    "yara|sigma|wazuh",
+                    "name":         "<cluster_id or empty>",
+                    "content":      "<rule content>",
+                    "syntax_valid": 1,
+                }
+            ],
+            "signature": "<HMAC-SHA256 hex>",
+        }
+
+    An empty ``rules`` list is valid — the manifest is still signed so
+    fleet agents can detect an intentionally-empty scoped set vs. a
+    network failure (no response at all).
+
+    Args:
+        conn:         Open SQLite connection.
+        tag:          Scoping tag to filter rules by.
+        key:          Raw HMAC key bytes (SHAFERHUND_AUDIT_KEY).
+        generated_at: Optional ISO-8601 timestamp override; defaults to
+                      current UTC time.  Useful for deterministic tests.
+
+    Returns:
+        Signed manifest dict.
+    """
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).isoformat()
+
+    rule_rows = list_rules_for_tag(conn, tag, deployed_only=True)
+
+    rules_list = [
+        {
+            "id":           str(row["id"]),
+            "rule_type":    row["rule_type"] or "",
+            "name":         row["cluster_id"] or "",
+            "content":      row["rule_content"] or "",
+            "syntax_valid": int(row["syntax_valid"]) if row["syntax_valid"] is not None else 0,
+        }
+        for row in rule_rows
+    ]
+
+    version = 1
+    canon = canonical_manifest_body(version, tag, generated_at, rules_list)
+    manifest_id = hashlib.sha256(canon).hexdigest()
+    signature = sign_manifest(key, canon)
+
+    return {
+        "version":      version,
+        "manifest_id":  manifest_id,
+        "tag":          tag,
+        "generated_at": generated_at,
+        "rules":        rules_list,
+        "signature":    signature,
+    }

--- a/agent/main.py
+++ b/agent/main.py
@@ -161,6 +161,14 @@ from .models import (
     count_audit_events,
     list_audit_events,
 )
+from . import fleet as _fleet
+from .models import (
+    list_all_tags,
+    list_tags_for_rule,
+    tag_rule,
+    untag_rule,
+)
+from .canary import sanitize_alert_field as _sanitize
 
 log = logging.getLogger(__name__)
 
@@ -1447,6 +1455,154 @@ async def verify_audit_chain() -> JSONResponse:
 
     result = _audit.verify_chain(_db, _audit_hmac_key)
     return JSONResponse(result)
+
+
+# ---------------------------------------------------------------------------
+# Fleet manifest routes (Phase 6 Wave A4, REQ-P0-P6-001)
+#
+# @decision DEC-FLEET-P6-001
+# @title HMAC-signed fleet manifest endpoint; operator role required
+# @status accepted
+# @rationale Fleet agents need to pull a scoped, tamper-evident list of rules
+#            without individual per-rule credentials. The manifest is signed
+#            with the operator HMAC key (SHAFERHUND_AUDIT_KEY) so fleet agents
+#            can verify integrity without a DB connection. operator role is the
+#            minimum required because reading manifests reveals deployed rule
+#            content — this is operational data, not a public health check.
+#            Tag CRUD routes also require operator so viewers cannot modify
+#            rule scoping, which is a write-side operation.
+#
+# Route RBAC for fleet routes (extends Wave A2 table, REQ-P0-P6-004):
+#   GET  /fleet/manifest/{tag}        — operator  (reveals deployed rule content)
+#   POST /rules/{rule_id}/tag         — operator  (write: scoping change)
+#   DELETE /rules/{rule_id}/tag/{tag} — operator  (write: scoping change)
+#   GET  /rules/{rule_id}/tags        — viewer    (read-only metadata)
+#   GET  /tags                        — viewer    (read-only metadata)
+# ---------------------------------------------------------------------------
+
+
+@app.get(
+    "/fleet/manifest/{tag}",
+    dependencies=[Depends(_require_role("operator"))],
+)
+async def get_fleet_manifest(tag: str) -> JSONResponse:
+    """Return a signed fleet manifest for all deployed rules tagged with *tag*.
+
+    The manifest JSON includes: version, manifest_id (SHA-256 of body),
+    tag, generated_at, rules list, and an HMAC-SHA256 signature over the
+    canonical body.  Only rules with deployed=1 appear (DEC-FLEET-P6-002).
+
+    Fleet agents (Wave B2) call this endpoint, verify the signature against
+    their pre-shared secret (SHAFERHUND_AUDIT_KEY), and apply the rules.
+    An empty rules list is a valid response — it means no deployed rules
+    carry this tag.
+
+    Auth: operator or admin token required.
+    """
+    if _db is None or not _audit_hmac_key:
+        raise HTTPException(status_code=503, detail="Database or audit key not ready")
+
+    safe_tag = _sanitize(tag)
+    if not safe_tag:
+        raise HTTPException(status_code=400, detail="tag must not be empty")
+
+    manifest = _fleet.build_manifest(_db, safe_tag, _audit_hmac_key)
+    return JSONResponse(manifest)
+
+
+@app.post(
+    "/rules/{rule_id}/tag",
+    dependencies=[Depends(_require_role("operator"))],
+)
+async def add_rule_tag(rule_id: str, request: Request) -> JSONResponse:
+    """Attach a scoping tag to a rule.  Idempotent — tagging twice is a no-op.
+
+    Request body: ``{"tag": "group:web"}``
+
+    Returns the updated list of tags for the rule.
+
+    Auth: operator or admin token required.
+    """
+    if _db is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+
+    raw_tag = body.get("tag", "") if isinstance(body, dict) else ""
+    safe_tag = _sanitize(str(raw_tag)) if raw_tag else ""
+    if not safe_tag:
+        raise HTTPException(status_code=400, detail="'tag' field is required and must not be empty")
+
+    safe_rule_id = _sanitize(rule_id)
+    tag_rule(_db, safe_rule_id, safe_tag)
+    tags = list_tags_for_rule(_db, safe_rule_id)
+    return JSONResponse({"rule_id": safe_rule_id, "tags": tags})
+
+
+@app.delete(
+    "/rules/{rule_id}/tag/{tag}",
+    dependencies=[Depends(_require_role("operator"))],
+)
+async def remove_rule_tag(rule_id: str, tag: str) -> JSONResponse:
+    """Remove a scoping tag from a rule.
+
+    Returns the updated list of tags.  If the tag was not present, returns
+    the current tag list without error (idempotent DELETE).
+
+    Auth: operator or admin token required.
+    """
+    if _db is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    safe_rule_id = _sanitize(rule_id)
+    safe_tag = _sanitize(tag)
+    untag_rule(_db, safe_rule_id, safe_tag)
+    tags = list_tags_for_rule(_db, safe_rule_id)
+    return JSONResponse({"rule_id": safe_rule_id, "tags": tags})
+
+
+@app.get(
+    "/rules/{rule_id}/tags",
+    dependencies=[Depends(_require_role("viewer"))],
+)
+async def get_rule_tags(rule_id: str) -> JSONResponse:
+    """List all scoping tags currently applied to a rule.
+
+    Returns ``{"rule_id": "...", "tags": [...]}`` where tags is alphabetically
+    sorted.  Returns an empty list for a rule with no tags (or an unknown rule).
+
+    Auth: viewer or higher token required.
+    """
+    if _db is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    safe_rule_id = _sanitize(rule_id)
+    tags = list_tags_for_rule(_db, safe_rule_id)
+    return JSONResponse({"rule_id": safe_rule_id, "tags": tags})
+
+
+@app.get(
+    "/tags",
+    dependencies=[Depends(_require_role("viewer"))],
+)
+async def get_all_tags() -> JSONResponse:
+    """List all distinct rule tags with their rule counts.
+
+    Returns ``{"tags": [{"tag": "group:web", "rule_count": 3}, ...]}``
+    ordered alphabetically by tag name.
+
+    Auth: viewer or higher token required.
+    """
+    if _db is None:
+        raise HTTPException(status_code=503, detail="Database not ready")
+
+    tag_rows = list_all_tags(_db)
+    return JSONResponse({
+        "tags": [{"tag": t, "rule_count": c} for t, c in tag_rows]
+    })
 
 
 async def _canary_enqueue(alert_obj) -> None:

--- a/agent/models.py
+++ b/agent/models.py
@@ -619,6 +619,48 @@ CREATE INDEX IF NOT EXISTS idx_audit_log_actor ON audit_log(actor_username);
 """
 
 
+# ---------------------------------------------------------------------------
+# Phase 6 Wave A4 schema additions — rule_tags table
+# (REQ-P0-P6-001, DEC-FLEET-P6-002, DEC-SCHEMA-P6-001)
+# ---------------------------------------------------------------------------
+#
+# rule_tags: join table linking rules to scoping tags (e.g. 'group:web').
+#
+# A "tag" is a short operator-assigned string that scopes which fleet agents
+# receive a rule.  The fleet manifest endpoint (GET /fleet/manifest/{tag})
+# returns all deployed rules that carry the requested tag, signed with the
+# operator HMAC key.  Rule scoping by tags (rather than per-rule ACLs) was
+# chosen per DEC-FLEET-P6-002 — coarse tag-based scoping matches real field
+# usage ('web tier', 'db tier') and is far simpler to operate than per-rule
+# ACL tables.
+#
+# Columns:
+#   rule_id    — FK into rules.id (TEXT UUID primary key).
+#   tag        — operator-supplied scoping tag; sanitized before insert.
+#   created_at — ISO-8601 UTC timestamp when the tag was applied.
+#
+# UNIQUE(rule_id, tag): same tag applied twice to the same rule is a no-op
+# via INSERT OR IGNORE (idempotent / upsert-style).
+#
+# Indexes on both tag and rule_id for efficient manifest queries.
+#
+# DEC-SCHEMA-P6-001: CREATE TABLE IF NOT EXISTS — idempotent for Phase 6
+#   Wave A1/A2/A3-baseline DBs.
+
+_RULE_TAGS_SQL = """
+CREATE TABLE IF NOT EXISTS rule_tags (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    rule_id     TEXT    NOT NULL REFERENCES rules(id),
+    tag         TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL,
+    UNIQUE(rule_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rule_tags_tag     ON rule_tags(tag);
+CREATE INDEX IF NOT EXISTS idx_rule_tags_rule_id ON rule_tags(rule_id);
+"""
+
+
 def init_db(db_path: str) -> sqlite3.Connection:
     """Open (or create) the SQLite database and apply schema.
 
@@ -732,6 +774,9 @@ def init_db(db_path: str) -> sqlite3.Connection:
 
     # Phase 6 Wave A3: audit_log table (REQ-P0-P6-005, DEC-AUDIT-P6-001).
     conn.executescript(_AUDIT_LOG_SQL)
+
+    # Phase 6 Wave A4: rule_tags table (REQ-P0-P6-001, DEC-SCHEMA-P6-001).
+    conn.executescript(_RULE_TAGS_SQL)
 
     conn.commit()
     log.info("Database initialised at %s", db_path)
@@ -2630,3 +2675,129 @@ def count_audit_events(conn: sqlite3.Connection) -> int:
     """Return the total number of rows in audit_log."""
     row = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()
     return row[0] if row else 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 Wave A4 — rule_tags CRUD helpers (REQ-P0-P6-001, DEC-FLEET-P6-002)
+# ---------------------------------------------------------------------------
+
+
+def tag_rule(conn: sqlite3.Connection, rule_id: str, tag: str) -> int:
+    """Associate *tag* with *rule_id*; idempotent via INSERT OR IGNORE.
+
+    Returns the number of rows inserted (1 on first tag application,
+    0 if the tag was already present — INSERT OR IGNORE behaviour).
+
+    Args:
+        conn:    Open SQLite connection.
+        rule_id: TEXT UUID of the rule (rules.id).
+        tag:     Operator-assigned scoping tag (e.g. 'group:web').
+                 Caller is responsible for sanitizing via sanitize_alert_field
+                 before passing here.
+
+    Returns:
+        Rows affected (1 if newly inserted, 0 if already present).
+    """
+    ts = datetime.now(timezone.utc).isoformat()
+    with get_cursor(conn) as cur:
+        cur.execute(
+            """
+            INSERT OR IGNORE INTO rule_tags (rule_id, tag, created_at)
+            VALUES (?, ?, ?)
+            """,
+            (rule_id, tag, ts),
+        )
+        return cur.rowcount
+
+
+def untag_rule(conn: sqlite3.Connection, rule_id: str, tag: str) -> int:
+    """Remove *tag* from *rule_id*.
+
+    Returns rows deleted (1 if the tag was present, 0 if it was not).
+
+    Args:
+        conn:    Open SQLite connection.
+        rule_id: TEXT UUID of the rule.
+        tag:     Tag string to remove.
+    """
+    with get_cursor(conn) as cur:
+        cur.execute(
+            "DELETE FROM rule_tags WHERE rule_id = ? AND tag = ?",
+            (rule_id, tag),
+        )
+        return cur.rowcount
+
+
+def list_tags_for_rule(conn: sqlite3.Connection, rule_id: str) -> list[str]:
+    """Return all tags associated with *rule_id*, ordered alphabetically.
+
+    Returns an empty list if the rule has no tags or does not exist.
+    """
+    rows = conn.execute(
+        "SELECT tag FROM rule_tags WHERE rule_id = ? ORDER BY tag ASC",
+        (rule_id,),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def list_rules_for_tag(
+    conn: sqlite3.Connection,
+    tag: str,
+    deployed_only: bool = False,
+) -> list[sqlite3.Row]:
+    """Return all rules rows that carry *tag*, joined with rule_tags.
+
+    Args:
+        conn:          Open SQLite connection.
+        tag:           Tag string to filter by.
+        deployed_only: If True, only return rules with deployed=1.
+                       Fleet manifest uses deployed_only=True so undeployed
+                       rules are never leaked to fleet agents (DEC-FLEET-P6-002).
+
+    Returns:
+        List of rules sqlite3.Row objects (all columns from the rules table).
+        Ordered by rules.created_at ASC for deterministic manifest ordering.
+    """
+    if deployed_only:
+        rows = conn.execute(
+            """
+            SELECT r.*
+              FROM rules r
+              JOIN rule_tags rt ON rt.rule_id = r.id
+             WHERE rt.tag = ?
+               AND r.deployed = 1
+             ORDER BY r.created_at ASC
+            """,
+            (tag,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT r.*
+              FROM rules r
+              JOIN rule_tags rt ON rt.rule_id = r.id
+             WHERE rt.tag = ?
+             ORDER BY r.created_at ASC
+            """,
+            (tag,),
+        ).fetchall()
+    return rows
+
+
+def list_all_tags(conn: sqlite3.Connection) -> list[tuple[str, int]]:
+    """Return all distinct tags with rule_count, ordered by tag name.
+
+    Returns a list of (tag, rule_count) tuples where rule_count is the
+    number of rules (deployed or not) carrying that tag.
+
+    Returns an empty list when no tags exist.
+    """
+    rows = conn.execute(
+        """
+        SELECT tag, COUNT(*) AS rule_count
+          FROM rule_tags
+         GROUP BY tag
+         ORDER BY tag ASC
+        """
+    ).fetchall()
+    return [(row[0], row[1]) for row in rows]

--- a/tests/test_fleet_manifest.py
+++ b/tests/test_fleet_manifest.py
@@ -1,0 +1,290 @@
+"""
+Unit tests for Phase 6 Wave A4 fleet manifest pure functions.
+
+Tests cover: canonical_manifest_body, sign_manifest, verify_manifest,
+build_manifest.  All tests run against a real SQLite DB — no mocks.
+
+REQ-P0-P6-001 / DEC-FLEET-P6-001 / DEC-FLEET-P6-002
+"""
+import pytest
+
+from agent.fleet import (
+    build_manifest,
+    canonical_manifest_body,
+    sign_manifest,
+    verify_manifest,
+)
+from agent.models import (
+    init_db,
+    insert_rule,
+    tag_rule,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_KEY_A = bytes.fromhex("aa" * 32)
+_KEY_B = bytes.fromhex("bb" * 32)
+_FIXED_TS = "2026-04-25T16:30:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def conn(tmp_path):
+    db = init_db(str(tmp_path / "test.db"))
+    yield db
+    db.close()
+
+
+def _seed_deployed_rule(conn, rule_id="rule-001", tag="group:web", rule_type="yara"):
+    """Insert a deployed rule and tag it.
+
+    cluster_id=None avoids FK constraint — NULL is always valid for nullable
+    FK columns in SQLite even with foreign_keys=ON.
+    """
+    insert_rule(
+        conn,
+        rule_id=rule_id,
+        cluster_id=None,
+        rule_type=rule_type,
+        rule_content=f"rule {rule_id} {{}}",
+        syntax_valid=True,
+    )
+    conn.execute("UPDATE rules SET deployed = 1 WHERE id = ?", (rule_id,))
+    conn.commit()
+    tag_rule(conn, rule_id, tag)
+    return rule_id
+
+
+def _seed_undeployed_rule(conn, rule_id="rule-draft", tag="group:web"):
+    """Insert a rule with deployed=0 and tag it."""
+    insert_rule(
+        conn,
+        rule_id=rule_id,
+        cluster_id=None,
+        rule_type="yara",
+        rule_content="rule draft {}",
+        syntax_valid=False,
+    )
+    # deployed stays 0 (default)
+    tag_rule(conn, rule_id, tag)
+    return rule_id
+
+
+# ---------------------------------------------------------------------------
+# canonical_manifest_body
+# ---------------------------------------------------------------------------
+
+def test_canonical_body_is_bytes():
+    body = canonical_manifest_body(1, "group:web", _FIXED_TS, [])
+    assert isinstance(body, bytes)
+
+
+def test_canonical_body_same_inputs_same_output():
+    rules = [{"id": "r1", "rule_type": "yara", "name": "c1", "content": "x", "syntax_valid": 1}]
+    b1 = canonical_manifest_body(1, "group:web", _FIXED_TS, rules)
+    b2 = canonical_manifest_body(1, "group:web", _FIXED_TS, rules)
+    assert b1 == b2
+
+
+def test_canonical_body_field_order_matters():
+    """Swapping version and tag (different field positions) must produce different bytes."""
+    body_v1 = canonical_manifest_body(1, "group:web", _FIXED_TS, [])
+    body_v2 = canonical_manifest_body(2, "group:web", _FIXED_TS, [])
+    assert body_v1 != body_v2
+
+
+def test_canonical_body_tag_change_produces_different_bytes():
+    b1 = canonical_manifest_body(1, "group:web", _FIXED_TS, [])
+    b2 = canonical_manifest_body(1, "group:db", _FIXED_TS, [])
+    assert b1 != b2
+
+
+def test_canonical_body_empty_rules_is_valid():
+    body = canonical_manifest_body(1, "group:web", _FIXED_TS, [])
+    assert len(body) > 0
+
+
+# ---------------------------------------------------------------------------
+# sign_manifest
+# ---------------------------------------------------------------------------
+
+def test_sign_manifest_returns_hex_string():
+    body = canonical_manifest_body(1, "group:web", _FIXED_TS, [])
+    sig = sign_manifest(_KEY_A, body)
+    assert isinstance(sig, str)
+    assert len(sig) == 64  # SHA-256 hex digest
+
+
+def test_sign_manifest_deterministic():
+    body = canonical_manifest_body(1, "group:web", _FIXED_TS, [])
+    sig1 = sign_manifest(_KEY_A, body)
+    sig2 = sign_manifest(_KEY_A, body)
+    assert sig1 == sig2
+
+
+def test_sign_manifest_different_keys_different_sigs():
+    body = canonical_manifest_body(1, "group:web", _FIXED_TS, [])
+    sig_a = sign_manifest(_KEY_A, body)
+    sig_b = sign_manifest(_KEY_B, body)
+    assert sig_a != sig_b
+
+
+# ---------------------------------------------------------------------------
+# verify_manifest
+# ---------------------------------------------------------------------------
+
+def test_verify_manifest_round_trip_valid(conn):
+    """sign then verify with same key → True."""
+    _seed_deployed_rule(conn)
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    assert verify_manifest(manifest, _KEY_A) is True
+
+
+def test_verify_manifest_wrong_key(conn):
+    """Verify with a different key → False."""
+    _seed_deployed_rule(conn)
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    assert verify_manifest(manifest, _KEY_B) is False
+
+
+def test_verify_manifest_tampered_rule_content(conn):
+    """Mutate a rule's content field after signing → verify returns False."""
+    _seed_deployed_rule(conn)
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    # Tamper: change first rule's content
+    tampered = dict(manifest)
+    tampered["rules"] = [dict(r) for r in manifest["rules"]]
+    tampered["rules"][0]["content"] = "TAMPERED"
+    assert verify_manifest(tampered, _KEY_A) is False
+
+
+def test_verify_manifest_tampered_signature(conn):
+    """Flip a hex char in the stored signature → verify returns False."""
+    _seed_deployed_rule(conn)
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    tampered = dict(manifest)
+    # Flip the first character of the hex signature
+    original_sig = manifest["signature"]
+    flipped_char = "0" if original_sig[0] != "0" else "1"
+    tampered["signature"] = flipped_char + original_sig[1:]
+    assert verify_manifest(tampered, _KEY_A) is False
+
+
+def test_verify_manifest_missing_field():
+    """verify_manifest with a dict missing required fields → False (no exception)."""
+    bad = {"version": 1, "tag": "x"}  # missing signature, rules, generated_at
+    assert verify_manifest(bad, _KEY_A) is False
+
+
+def test_verify_manifest_empty_rules_valid():
+    """Empty-rules manifest (no deployed rules for tag) still verifies correctly."""
+    body = canonical_manifest_body(1, "group:empty", _FIXED_TS, [])
+    sig = sign_manifest(_KEY_A, body)
+    manifest = {
+        "version": 1,
+        "manifest_id": "x",
+        "tag": "group:empty",
+        "generated_at": _FIXED_TS,
+        "rules": [],
+        "signature": sig,
+    }
+    assert verify_manifest(manifest, _KEY_A) is True
+
+
+# ---------------------------------------------------------------------------
+# build_manifest
+# ---------------------------------------------------------------------------
+
+def test_build_manifest_empty_tag(conn):
+    """No rules tagged → manifest has empty rules array; signature is valid."""
+    manifest = build_manifest(conn, "group:nonexistent", _KEY_A, generated_at=_FIXED_TS)
+    assert manifest["version"] == 1
+    assert manifest["tag"] == "group:nonexistent"
+    assert manifest["rules"] == []
+    assert "signature" in manifest
+    assert "manifest_id" in manifest
+    assert verify_manifest(manifest, _KEY_A) is True
+
+
+def test_build_manifest_excludes_undeployed(conn):
+    """An undeployed rule tagged for the group must not appear in the manifest."""
+    _seed_undeployed_rule(conn, "rule-draft", "group:web")
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    assert manifest["rules"] == []
+
+
+def test_build_manifest_includes_deployed(conn):
+    """A deployed rule tagged for the group appears in the manifest."""
+    _seed_deployed_rule(conn, "rule-001", "group:web")
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    assert len(manifest["rules"]) == 1
+    assert manifest["rules"][0]["id"] == "rule-001"
+
+
+def test_build_manifest_excludes_undeployed_includes_deployed(conn):
+    """Mixed deployed/undeployed: only deployed rule appears."""
+    _seed_deployed_rule(conn, "rule-deployed", "group:web")
+    _seed_undeployed_rule(conn, "rule-draft", "group:web")
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    assert len(manifest["rules"]) == 1
+    assert manifest["rules"][0]["id"] == "rule-deployed"
+
+
+def test_build_manifest_signature_deterministic(conn):
+    """Same DB state and same generated_at → identical signature."""
+    _seed_deployed_rule(conn)
+    m1 = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    m2 = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    assert m1["signature"] == m2["signature"]
+    assert m1["manifest_id"] == m2["manifest_id"]
+
+
+def test_manifest_id_changes_with_content(conn):
+    """Two different rule sets → different manifest_ids."""
+    _seed_deployed_rule(conn, "rule-001", "group:web")
+    m1 = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+
+    _seed_deployed_rule(conn, "rule-002", "group:web")
+    m2 = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+
+    assert m1["manifest_id"] != m2["manifest_id"]
+
+
+def test_build_manifest_required_fields(conn):
+    """Manifest dict contains all required top-level fields."""
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    for field in ("version", "manifest_id", "tag", "generated_at", "rules", "signature"):
+        assert field in manifest, f"missing field: {field}"
+
+
+def test_build_manifest_rule_entry_fields(conn):
+    """Each rule entry contains the required fields."""
+    _seed_deployed_rule(conn, "rule-001", "group:web", rule_type="sigma")
+    manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    assert len(manifest["rules"]) == 1
+    rule = manifest["rules"][0]
+    for field in ("id", "rule_type", "name", "content", "syntax_valid"):
+        assert field in rule, f"rule entry missing field: {field}"
+    assert rule["rule_type"] == "sigma"
+
+
+def test_build_manifest_scoped_by_tag(conn):
+    """Rules tagged for 'group:db' do not appear in 'group:web' manifest."""
+    _seed_deployed_rule(conn, "web-rule", "group:web")
+    _seed_deployed_rule(conn, "db-rule", "group:db")
+
+    web_manifest = build_manifest(conn, "group:web", _KEY_A, generated_at=_FIXED_TS)
+    db_manifest = build_manifest(conn, "group:db", _KEY_A, generated_at=_FIXED_TS)
+
+    web_ids = {r["id"] for r in web_manifest["rules"]}
+    db_ids = {r["id"] for r in db_manifest["rules"]}
+
+    assert "web-rule" in web_ids
+    assert "db-rule" not in web_ids
+    assert "db-rule" in db_ids
+    assert "web-rule" not in db_ids

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -1,0 +1,389 @@
+"""
+Integration tests for Phase 6 Wave A4 fleet manifest routes.
+
+Tests use FastAPI TestClient against a real SQLite DB.  Auth is exercised
+via real user/token rows — no mocks for internal auth (Sacred Practice #5).
+
+Routes under test:
+  GET  /fleet/manifest/{tag}        — operator
+  POST /rules/{rule_id}/tag         — operator
+  DELETE /rules/{rule_id}/tag/{tag} — operator
+  GET  /rules/{rule_id}/tags        — viewer
+  GET  /tags                        — viewer
+
+REQ-P0-P6-001 / DEC-FLEET-P6-001 / DEC-FLEET-P6-002
+"""
+import os
+import pytest
+
+from fastapi.testclient import TestClient
+
+from agent.auth import generate_token, hash_password
+from agent.fleet import verify_manifest
+from agent.models import (
+    init_db,
+    insert_rule,
+    insert_user,
+    insert_user_token,
+    tag_rule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+AUDIT_KEY_HEX = "aa" * 32  # 32-byte key as hex string
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    return str(tmp_path / "fleet_routes.db")
+
+
+@pytest.fixture()
+def test_client(db_path, monkeypatch):
+    """Return a TestClient with multi-mode auth and a real DB.
+
+    Sets environment before importing app so Settings picks up the values.
+    """
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("SHAFERHUND_AUTH_MODE", "multi")
+    monkeypatch.setenv("SHAFERHUND_AUDIT_KEY", AUDIT_KEY_HEX)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-dummy")
+    monkeypatch.delenv("SHAFERHUND_TOKEN", raising=False)
+
+    from agent.main import app
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client
+
+
+@pytest.fixture()
+def db(db_path):
+    """Direct DB connection for seeding data outside the app."""
+    conn = init_db(db_path)
+    yield conn
+    conn.close()
+
+
+def _create_user_with_token(db, username, role):
+    """Create a user + token, return the raw bearer string."""
+    uid = insert_user(db, username=username, password_hash=hash_password("pass"), role=role)
+    raw, token_hash = generate_token()
+    insert_user_token(db, user_id=uid, token_hash=token_hash, name=f"{username}-token", expires_at=None)
+    return raw
+
+
+def _seed_deployed_rule(db, rule_id="rule-001", tag="group:web"):
+    """Insert a deployed rule and tag it, return rule_id.
+
+    cluster_id=None avoids FK constraint — NULL is always valid for nullable
+    FK columns in SQLite even with foreign_keys=ON.
+    """
+    insert_rule(
+        db,
+        rule_id=rule_id,
+        cluster_id=None,
+        rule_type="yara",
+        rule_content=f"rule {rule_id} {{}}",
+        syntax_valid=True,
+    )
+    db.execute("UPDATE rules SET deployed = 1 WHERE id = ?", (rule_id,))
+    db.commit()
+    if tag:
+        tag_rule(db, rule_id, tag)
+    return rule_id
+
+
+def _seed_undeployed_rule(db, rule_id="rule-draft", tag="group:web"):
+    insert_rule(
+        db,
+        rule_id=rule_id,
+        cluster_id=None,
+        rule_type="yara",
+        rule_content="rule draft {}",
+        syntax_valid=False,
+    )
+    # deployed stays 0 (default)
+    if tag:
+        tag_rule(db, rule_id, tag)
+    return rule_id
+
+
+# ---------------------------------------------------------------------------
+# GET /fleet/manifest/{tag} — auth gate
+# ---------------------------------------------------------------------------
+
+def test_fleet_manifest_no_auth(test_client):
+    r = test_client.get("/fleet/manifest/group:web")
+    assert r.status_code == 401
+
+
+def test_fleet_manifest_viewer_is_forbidden(test_client, db):
+    viewer_token = _create_user_with_token(db, "viewer1", "viewer")
+    r = test_client.get(
+        "/fleet/manifest/group:web",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 403
+
+
+def test_fleet_manifest_operator_allowed(test_client, db):
+    op_token = _create_user_with_token(db, "op1", "operator")
+    r = test_client.get(
+        "/fleet/manifest/group:web",
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert r.status_code == 200
+
+
+def test_fleet_manifest_admin_allowed(test_client, db):
+    admin_token = _create_user_with_token(db, "admin1", "admin")
+    r = test_client.get(
+        "/fleet/manifest/group:web",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /fleet/manifest/{tag} — content
+# ---------------------------------------------------------------------------
+
+def test_fleet_manifest_empty_tag_returns_valid_manifest(test_client, db):
+    """Empty tag → valid manifest with empty rules list and valid signature."""
+    op_token = _create_user_with_token(db, "op2", "operator")
+    r = test_client.get(
+        "/fleet/manifest/group:empty",
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert r.status_code == 200
+    m = r.json()
+    assert m["version"] == 1
+    assert m["tag"] == "group:empty"
+    assert m["rules"] == []
+    assert "signature" in m
+    assert "manifest_id" in m
+
+
+def test_fleet_manifest_includes_deployed_rule(test_client, db):
+    """Tagged deployed rule appears in manifest response."""
+    _seed_deployed_rule(db, "rule-001", "group:web")
+    op_token = _create_user_with_token(db, "op3", "operator")
+
+    r = test_client.get(
+        "/fleet/manifest/group:web",
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert r.status_code == 200
+    m = r.json()
+    assert len(m["rules"]) == 1
+    assert m["rules"][0]["id"] == "rule-001"
+
+
+def test_fleet_manifest_excludes_undeployed_rule(test_client, db):
+    """Tagged but undeployed rule must NOT appear in manifest (DEC-FLEET-P6-002)."""
+    _seed_undeployed_rule(db, "rule-draft", "group:web")
+    op_token = _create_user_with_token(db, "op4", "operator")
+
+    r = test_client.get(
+        "/fleet/manifest/group:web",
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["rules"] == []
+
+
+def test_fleet_manifest_signature_verifies(test_client, db):
+    """Manifest signature verifies correctly using the audit key."""
+    _seed_deployed_rule(db, "rule-001", "group:web")
+    op_token = _create_user_with_token(db, "op5", "operator")
+
+    r = test_client.get(
+        "/fleet/manifest/group:web",
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert r.status_code == 200
+    manifest = r.json()
+    key_bytes = bytes.fromhex(AUDIT_KEY_HEX)
+    assert verify_manifest(manifest, key_bytes) is True
+
+
+def test_fleet_manifest_signature_fails_wrong_key(test_client, db):
+    """Manifest signature does not verify with a different key."""
+    _seed_deployed_rule(db, "rule-001", "group:web")
+    op_token = _create_user_with_token(db, "op6", "operator")
+
+    r = test_client.get(
+        "/fleet/manifest/group:web",
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    manifest = r.json()
+    wrong_key = bytes.fromhex("bb" * 32)
+    assert verify_manifest(manifest, wrong_key) is False
+
+
+# ---------------------------------------------------------------------------
+# POST /rules/{rule_id}/tag — round-trip
+# ---------------------------------------------------------------------------
+
+def test_tag_route_no_auth(test_client):
+    r = test_client.post("/rules/rule-001/tag", json={"tag": "group:web"})
+    assert r.status_code == 401
+
+
+def test_tag_route_viewer_is_forbidden(test_client, db):
+    viewer_token = _create_user_with_token(db, "viewer2", "viewer")
+    r = test_client.post(
+        "/rules/rule-001/tag",
+        json={"tag": "group:web"},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 403
+
+
+def test_tag_route_operator_can_tag(test_client, db):
+    _seed_deployed_rule(db, "rule-001", tag=None)
+    op_token = _create_user_with_token(db, "op7", "operator")
+
+    r = test_client.post(
+        "/rules/rule-001/tag",
+        json={"tag": "group:web"},
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "group:web" in body["tags"]
+
+
+def test_tag_then_manifest_roundtrip(test_client, db):
+    """POST /rules/{id}/tag → GET /fleet/manifest/{tag} returns the rule."""
+    _seed_deployed_rule(db, "rule-rt", tag=None)
+    op_token = _create_user_with_token(db, "op8", "operator")
+    auth = {"Authorization": f"Bearer {op_token}"}
+
+    # Tag the rule
+    r = test_client.post("/rules/rule-rt/tag", json={"tag": "group:roundtrip"}, headers=auth)
+    assert r.status_code == 200
+
+    # Manifest should now include the rule
+    r2 = test_client.get("/fleet/manifest/group:roundtrip", headers=auth)
+    assert r2.status_code == 200
+    ids = {rule["id"] for rule in r2.json()["rules"]}
+    assert "rule-rt" in ids
+
+
+def test_tag_route_missing_tag_field(test_client, db):
+    op_token = _create_user_with_token(db, "op9", "operator")
+    r = test_client.post(
+        "/rules/rule-001/tag",
+        json={"wrong_field": "x"},
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# DELETE /rules/{rule_id}/tag/{tag}
+# ---------------------------------------------------------------------------
+
+def test_untag_route_no_auth(test_client):
+    r = test_client.delete("/rules/rule-001/tag/group:web")
+    assert r.status_code == 401
+
+
+def test_untag_route_viewer_is_forbidden(test_client, db):
+    viewer_token = _create_user_with_token(db, "viewer3", "viewer")
+    r = test_client.delete(
+        "/rules/rule-001/tag/group:web",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 403
+
+
+def test_untag_then_manifest_roundtrip(test_client, db):
+    """DELETE /rules/{id}/tag/{tag} → rule no longer in manifest."""
+    _seed_deployed_rule(db, "rule-ut", "group:untag")
+    op_token = _create_user_with_token(db, "op10", "operator")
+    auth = {"Authorization": f"Bearer {op_token}"}
+
+    # Confirm rule is in manifest before untag
+    r = test_client.get("/fleet/manifest/group:untag", headers=auth)
+    assert any(rule["id"] == "rule-ut" for rule in r.json()["rules"])
+
+    # Untag
+    r2 = test_client.delete("/rules/rule-ut/tag/group:untag", headers=auth)
+    assert r2.status_code == 200
+    assert r2.json()["tags"] == []
+
+    # Manifest should no longer contain the rule
+    r3 = test_client.get("/fleet/manifest/group:untag", headers=auth)
+    assert r3.json()["rules"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /rules/{rule_id}/tags
+# ---------------------------------------------------------------------------
+
+def test_get_rule_tags_no_auth(test_client):
+    r = test_client.get("/rules/rule-001/tags")
+    assert r.status_code == 401
+
+
+def test_get_rule_tags_viewer_allowed(test_client, db):
+    _seed_deployed_rule(db, "rule-001", "group:web")
+    viewer_token = _create_user_with_token(db, "viewer4", "viewer")
+
+    r = test_client.get(
+        "/rules/rule-001/tags",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200
+    assert "group:web" in r.json()["tags"]
+
+
+def test_get_rule_tags_empty(test_client, db):
+    _seed_deployed_rule(db, "rule-notag", tag=None)
+    viewer_token = _create_user_with_token(db, "viewer5", "viewer")
+
+    r = test_client.get(
+        "/rules/rule-notag/tags",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["tags"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /tags
+# ---------------------------------------------------------------------------
+
+def test_get_all_tags_no_auth(test_client):
+    r = test_client.get("/tags")
+    assert r.status_code == 401
+
+
+def test_get_all_tags_viewer_allowed(test_client, db):
+    _seed_deployed_rule(db, "rule-001", "group:web")
+    _seed_deployed_rule(db, "rule-002", "group:db")
+    viewer_token = _create_user_with_token(db, "viewer6", "viewer")
+
+    r = test_client.get(
+        "/tags",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200
+    tags_by_name = {t["tag"]: t["rule_count"] for t in r.json()["tags"]}
+    assert "group:web" in tags_by_name
+    assert "group:db" in tags_by_name
+
+
+def test_get_all_tags_empty(test_client, db):
+    viewer_token = _create_user_with_token(db, "viewer7", "viewer")
+
+    r = test_client.get(
+        "/tags",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["tags"] == []

--- a/tests/test_rule_tags_models.py
+++ b/tests/test_rule_tags_models.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for Phase 6 Wave A4 rule_tags CRUD helpers.
+
+Tests run against a real in-memory SQLite DB (no mocks) — consistent with
+Sacred Practice #5.  Each test gets a fresh DB via the ``conn`` fixture.
+
+REQ-P0-P6-001 / DEC-FLEET-P6-002 / DEC-SCHEMA-P6-001
+"""
+import pytest
+import sqlite3
+
+from agent.models import (
+    init_db,
+    insert_rule,
+    list_all_tags,
+    list_rules_for_tag,
+    list_tags_for_rule,
+    tag_rule,
+    untag_rule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def conn(tmp_path):
+    """Fresh in-memory-style SQLite DB for each test."""
+    db_file = str(tmp_path / "test.db")
+    c = init_db(db_file)
+    yield c
+    c.close()
+
+
+def _make_rule(conn, rule_id="rule-001", deployed=1):
+    """Insert a minimal rule row and return rule_id.
+
+    cluster_id=None avoids FK constraint on clusters.id — NULL is always
+    allowed for nullable FK columns in SQLite regardless of foreign_keys=ON.
+    """
+    insert_rule(
+        conn,
+        rule_id=rule_id,
+        cluster_id=None,
+        rule_type="yara",
+        rule_content="rule test {}",
+        syntax_valid=True,
+    )
+    if deployed:
+        conn.execute("UPDATE rules SET deployed = 1 WHERE id = ?", (rule_id,))
+        conn.commit()
+    return rule_id
+
+
+# ---------------------------------------------------------------------------
+# tag_rule
+# ---------------------------------------------------------------------------
+
+def test_tag_rule_basic(conn):
+    """tag_rule returns 1 (rows inserted) on first application."""
+    rid = _make_rule(conn)
+    result = tag_rule(conn, rid, "group:web")
+    assert result == 1
+
+
+def test_tag_rule_unique_constraint(conn):
+    """Same rule+tag applied twice inserts only one row (INSERT OR IGNORE)."""
+    rid = _make_rule(conn)
+    tag_rule(conn, rid, "group:web")
+    second = tag_rule(conn, rid, "group:web")
+    # INSERT OR IGNORE → rowcount 0 on duplicate
+    assert second == 0
+    rows = conn.execute(
+        "SELECT COUNT(*) FROM rule_tags WHERE rule_id = ? AND tag = ?",
+        (rid, "group:web"),
+    ).fetchone()[0]
+    assert rows == 1
+
+
+def test_tag_rule_multiple_tags(conn):
+    """A rule can carry multiple distinct tags."""
+    rid = _make_rule(conn)
+    tag_rule(conn, rid, "group:web")
+    tag_rule(conn, rid, "group:db")
+    tags = list_tags_for_rule(conn, rid)
+    assert "group:web" in tags
+    assert "group:db" in tags
+    assert len(tags) == 2
+
+
+# ---------------------------------------------------------------------------
+# untag_rule
+# ---------------------------------------------------------------------------
+
+def test_untag_rule_deletes_row(conn):
+    """untag_rule removes the tag and returns 1."""
+    rid = _make_rule(conn)
+    tag_rule(conn, rid, "group:web")
+    deleted = untag_rule(conn, rid, "group:web")
+    assert deleted == 1
+    tags = list_tags_for_rule(conn, rid)
+    assert tags == []
+
+
+def test_untag_rule_not_present_returns_zero(conn):
+    """untag_rule on a tag that was never applied returns 0 (idempotent)."""
+    rid = _make_rule(conn)
+    result = untag_rule(conn, rid, "group:missing")
+    assert result == 0
+
+
+def test_untag_rule_leaves_other_tags(conn):
+    """untag_rule removes only the targeted tag; siblings survive."""
+    rid = _make_rule(conn)
+    tag_rule(conn, rid, "group:web")
+    tag_rule(conn, rid, "group:db")
+    untag_rule(conn, rid, "group:web")
+    tags = list_tags_for_rule(conn, rid)
+    assert tags == ["group:db"]
+
+
+# ---------------------------------------------------------------------------
+# list_tags_for_rule
+# ---------------------------------------------------------------------------
+
+def test_list_tags_for_rule_returns_all_tags(conn):
+    """list_tags_for_rule returns every tag for the rule, sorted."""
+    rid = _make_rule(conn)
+    tag_rule(conn, rid, "group:web")
+    tag_rule(conn, rid, "env:prod")
+    tag_rule(conn, rid, "tier:dmz")
+    tags = list_tags_for_rule(conn, rid)
+    assert tags == sorted(["group:web", "env:prod", "tier:dmz"])
+
+
+def test_list_tags_for_rule_unknown_rule(conn):
+    """list_tags_for_rule returns empty list for a rule that doesn't exist."""
+    tags = list_tags_for_rule(conn, "nonexistent-uuid")
+    assert tags == []
+
+
+def test_list_tags_for_rule_empty(conn):
+    """list_tags_for_rule returns empty list for a rule with no tags."""
+    rid = _make_rule(conn)
+    tags = list_tags_for_rule(conn, rid)
+    assert tags == []
+
+
+# ---------------------------------------------------------------------------
+# list_rules_for_tag
+# ---------------------------------------------------------------------------
+
+def test_list_rules_for_tag_includes_only_tagged(conn):
+    """list_rules_for_tag returns only rules with that specific tag."""
+    rid1 = _make_rule(conn, "rule-a")
+    rid2 = _make_rule(conn, "rule-b")
+    tag_rule(conn, rid1, "group:web")
+    tag_rule(conn, rid2, "group:db")
+
+    web_rules = list_rules_for_tag(conn, "group:web")
+    assert len(web_rules) == 1
+    assert web_rules[0]["id"] == rid1
+
+
+def test_list_rules_for_tag_deployed_only_excludes_undeployed(conn):
+    """deployed_only=True excludes rules with deployed=0."""
+    rid = _make_rule(conn, "rule-draft", deployed=0)
+    tag_rule(conn, rid, "group:web")
+
+    deployed = list_rules_for_tag(conn, "group:web", deployed_only=True)
+    assert deployed == []
+
+    all_rules = list_rules_for_tag(conn, "group:web", deployed_only=False)
+    assert len(all_rules) == 1
+
+
+def test_list_rules_for_tag_empty_tag(conn):
+    """list_rules_for_tag returns empty list for a tag with no rules."""
+    rows = list_rules_for_tag(conn, "group:nonexistent")
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# list_all_tags
+# ---------------------------------------------------------------------------
+
+def test_list_all_tags_with_counts(conn):
+    """list_all_tags returns each distinct tag with its rule_count."""
+    rid1 = _make_rule(conn, "rule-1")
+    rid2 = _make_rule(conn, "rule-2")
+    rid3 = _make_rule(conn, "rule-3")
+
+    tag_rule(conn, rid1, "group:web")
+    tag_rule(conn, rid2, "group:web")
+    tag_rule(conn, rid3, "group:db")
+
+    result = list_all_tags(conn)
+    result_dict = {t: c for t, c in result}
+
+    assert result_dict["group:web"] == 2
+    assert result_dict["group:db"] == 1
+
+
+def test_list_all_tags_empty(conn):
+    """list_all_tags returns empty list when no tags exist."""
+    result = list_all_tags(conn)
+    assert result == []
+
+
+def test_list_all_tags_sorted_alphabetically(conn):
+    """list_all_tags returns tags in alphabetical order."""
+    rid = _make_rule(conn)
+    tag_rule(conn, rid, "zzz:last")
+    rid2 = _make_rule(conn, "rule-2")
+    tag_rule(conn, rid2, "aaa:first")
+    result = list_all_tags(conn)
+    tags_only = [t for t, _ in result]
+    assert tags_only == sorted(tags_only)


### PR DESCRIPTION
## Scope

Adds `rule_tags` table for scoping rules to fleet agents + scoped fleet manifest server with HMAC signing using the same operator pre-shared key as Wave A3's audit chain. Closes Wave A of Phase 6.

**6 files / +1478 lines:**
- `agent/fleet.py` (NEW, 253 lines) — `build_manifest`, `canonical_manifest_body`, `sign_manifest`, `verify_manifest`
- `agent/models.py` — `rule_tags` table + 5 CRUD helpers
- `agent/main.py` — 5 fleet routes (RBAC-tagged)
- 3 new test files — 61 new tests

## RBAC Route Matrix

| Route | Role |
|---|---|
| `GET /fleet/manifest/{tag}` | operator |
| `POST /rules/{rule_id}/tag` | operator |
| `DELETE /rules/{rule_id}/tag/{tag}` | operator |
| `GET /rules/{rule_id}/tags` | viewer |
| `GET /tags` | viewer |

## Verification (AUTOVERIFY: CLEAN, user-approved)

- **519 passed / 2 skipped / 0 failed** (+61 over Wave A3)
- TOOLS still 9 (no orchestrator surface change)
- **Auth gate matrix:** 15 status codes correct across all 5 routes — no bypass
- **Tamper detection (5 vectors):**
  - clean=True
  - tampered_content=False
  - tampered_tag=False
  - tampered_signature=False
  - wrong_key=False
- **Deployed-only enforcement (DEC-FLEET-P6-002):** undeployed rules absent from manifest — no draft/pending leakage to fleet agents
- Round-trip: tag → manifest (64-char signature) → verify(correct)=True / verify(wrong)=False
- Untag round-trip clean; empty-tag manifest still signed and verifies
- Backwards-compat preserved: single-mode legacy token returns 200 on `/fleet/manifest/x` and `/tags`
- DB migration Wave A3 → A4 idempotent
- DEC-FLEET-P6-001/002 annotations in `agent/fleet.py` + `agent/main.py`

## Wave B Hardening Note (non-blocking)

`POST /rules/{rule_id}/tag` with non-existent `rule_id` returns **500** (unhandled `sqlite3.IntegrityError` from FK constraint) instead of **404**. NOT a security issue — FK correctly prevents the insert. Recommend wrapping at `main.py:1540` with `try/except sqlite3.IntegrityError -> 404` during Wave B.

Closes #72