### PR TITLE
feat(#74): fleet client container + entrypoint + integration test (REQ-P0-P6-002)

### DIFF
--- a/agent/fleet_client.py
+++ b/agent/fleet_client.py
@@ -1,0 +1,390 @@
+"""
+Shaferhund Phase 6 Wave B2 — Fleet client (REQ-P0-P6-002).
+
+Standalone polling client that fetches a signed rule manifest from the
+Shaferhund manager, verifies the HMAC signature, and writes rule files to
+a local directory so the host's Wazuh/Suricata agent can pick them up.
+
+This module is the *client* counterpart to agent/fleet.py (the server side).
+It is intentionally free of FastAPI, SQLite, and all other server-side
+dependencies so it can be packaged in a minimal container image alongside
+the remote Wazuh agent.
+
+Design decisions:
+
+@decision DEC-FLEET-P6-001
+@title HMAC-signed manifests over per-agent shared secret; real crypto signing is Phase 7
+@status accepted
+@rationale The pre-shared HMAC key model provides integrity + authenticity for
+           the manifest pull without a PKI. The manager signs the canonical
+           manifest body; the client re-derives the signature and compares with
+           hmac.compare_digest (constant-time). Tampered or wrong-key manifests
+           are rejected before any file is touched. Real cryptographic signing
+           (cosign/minisign) is REQ-NOGO-P6-007 — follow-up once the contract
+           is operational.
+
+@decision DEC-FLEET-P6-003
+@title Fleet client is a separate minimal module + container; verify_manifest reused from agent.fleet
+@status accepted
+@rationale The client only needs httpx + the HMAC verification function. Copying
+           verify_manifest into a second module would create a second source of
+           truth for the signature algorithm — a drift hazard. Instead, the client
+           imports agent.fleet.verify_manifest directly. The Dockerfile copies only
+           agent/__init__.py, agent/models.py, agent/fleet.py, and this module,
+           keeping the image surface small. agent/models.py is pulled in transitively
+           by agent/fleet.py (list_rules_for_tag import) but models.py itself is
+           stdlib-only so it costs nothing in extra dependencies.
+
+@decision DEC-FLEET-P6-005
+@title LocalStack-style integration test gated by FLEET_INTEGRATION=1; honours DEC-CLOUD-013
+@status accepted
+@rationale Consistent with the CloudTrail LocalStack gate (DEC-CLOUD-013). The default
+           pytest suite (addopts = -m "not integration") never runs the fleet client
+           integration test. Operators opt in by running:
+               pytest -m integration tests/integration/test_fleet_client_integration.py
+           This keeps CI green when the manager is not reachable.
+
+Public interface
+----------------
+fetch_manifest(url, bearer_token, timeout) -> dict
+    HTTP GET the manifest URL. Returns parsed JSON. Raises httpx.HTTPError on 4xx/5xx.
+
+verify_and_apply(manifest, key, rules_dir) -> dict
+    Verify HMAC signature (raises ValueError on invalid). Write rule files.
+    Remove stale files not present in the manifest. Returns summary dict.
+
+run_once(settings) -> dict
+    Fetch + verify + apply in one call.
+
+run_loop(settings, interval_seconds)
+    Async polling loop. Broad-except + log on error; never crashes.
+"""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from agent.fleet import verify_manifest
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Rule type → file extension mapping
+# ---------------------------------------------------------------------------
+
+_EXT_MAP = {
+    "yara": ".yar",
+    "sigma": ".yml",
+    "wazuh": ".xml",
+}
+
+_DEFAULT_EXT = ".rule"
+
+
+def _ext_for(rule_type: str) -> str:
+    """Return the file extension for a given rule type string."""
+    return _EXT_MAP.get((rule_type or "").lower().strip(), _DEFAULT_EXT)
+
+
+# ---------------------------------------------------------------------------
+# Manifest fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_manifest(
+    url: str,
+    bearer_token: Optional[str] = None,
+    timeout: float = 30.0,
+) -> dict:
+    """Fetch a signed rule manifest from the Shaferhund manager.
+
+    Performs a synchronous HTTP GET.  If *bearer_token* is provided it is sent
+    as an ``Authorization: Bearer <token>`` header.  The response body is
+    expected to be a JSON object matching the manifest shape produced by
+    ``agent.fleet.build_manifest``.
+
+    Args:
+        url:          Full URL of the manifest endpoint, e.g.
+                      ``http://manager:8000/fleet/manifest/edr-prod``.
+        bearer_token: Optional bearer token for auth-gated endpoints.
+        timeout:      Request timeout in seconds (default 30).
+
+    Returns:
+        Parsed JSON dict from the response body.
+
+    Raises:
+        httpx.HTTPStatusError: On 4xx / 5xx responses (raised by
+                               ``response.raise_for_status()``).
+        httpx.RequestError:    On connection failures, timeouts, etc.
+    """
+    headers: dict[str, str] = {}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(url, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Verify and apply
+# ---------------------------------------------------------------------------
+
+
+def verify_and_apply(
+    manifest: dict,
+    key: bytes,
+    rules_dir: str,
+) -> dict:
+    """Verify a manifest's HMAC signature and apply the rule files to disk.
+
+    Signature verification happens first — if it fails a ``ValueError`` is
+    raised and no files are touched.  On success:
+
+    1. For each rule in the manifest, write ``<rules_dir>/<rule_uuid>.<ext>``
+       where *ext* is derived from ``rule_type`` (``.yar`` / ``.yml`` /
+       ``.xml``).  Existing files are overwritten atomically.
+    2. Remove any files in ``rules_dir`` that were not present in the manifest
+       (stale cleanup — when a rule is untagged on the manager, the client
+       removes it locally on the next pull).
+
+    ``rules_dir`` is created if it does not exist.
+
+    Args:
+        manifest:  Full manifest dict as returned by ``fetch_manifest`` /
+                   ``agent.fleet.build_manifest``.
+        key:       Raw HMAC key bytes (hex-decoded from ``FLEET_HMAC_KEY``).
+        rules_dir: Local directory path where rule files are written.
+
+    Returns:
+        ``{rules_written: int, rules_removed: int, manifest_id: str}``
+
+    Raises:
+        ValueError: If ``verify_manifest`` returns False (invalid HMAC or
+                    missing fields).  The manifest_id is included in the
+                    message so operators can correlate without exposing the key.
+    """
+    manifest_id = manifest.get("manifest_id", "<unknown>")
+
+    if not verify_manifest(manifest, key):
+        raise ValueError(
+            f"Manifest signature verification failed for manifest_id={manifest_id!r}. "
+            "Check that FLEET_HMAC_KEY matches the key configured on the manager."
+        )
+
+    rules_path = Path(rules_dir)
+    rules_path.mkdir(parents=True, exist_ok=True)
+
+    rules_in_manifest: set[str] = set()
+    rules_written = 0
+
+    for rule in manifest.get("rules", []):
+        rule_id = rule.get("id", "")
+        rule_type = rule.get("rule_type", "")
+        content = rule.get("content", "")
+
+        if not rule_id:
+            log.warning("Manifest rule missing 'id' field — skipping")
+            continue
+
+        ext = _ext_for(rule_type)
+        filename = f"{rule_id}{ext}"
+        rules_in_manifest.add(filename)
+
+        file_path = rules_path / filename
+        # Atomic write: write to tmp then rename so the rule file is never
+        # partially written from the perspective of the rule engine reader.
+        tmp_path = rules_path / f".tmp_{filename}"
+        try:
+            tmp_path.write_text(content, encoding="utf-8")
+            tmp_path.rename(file_path)
+            rules_written += 1
+            log.debug("Wrote rule file: %s", file_path)
+        except OSError as exc:
+            log.error("Failed to write rule file %s: %s", file_path, exc)
+            # Re-raise so the caller knows the apply was partial
+            raise
+
+    # Remove stale files — anything in rules_dir that is NOT in the manifest.
+    # Only files matching the known extensions are considered managed.
+    managed_exts = set(_EXT_MAP.values()) | {_DEFAULT_EXT}
+    rules_removed = 0
+
+    for existing in list(rules_path.iterdir()):
+        if existing.is_file() and existing.suffix in managed_exts:
+            if existing.name not in rules_in_manifest:
+                try:
+                    existing.unlink()
+                    rules_removed += 1
+                    log.debug("Removed stale rule file: %s", existing)
+                except OSError as exc:
+                    log.warning("Could not remove stale file %s: %s", existing, exc)
+
+    log.info(
+        "Applied manifest %s: %d rules written, %d stale files removed",
+        manifest_id,
+        rules_written,
+        rules_removed,
+    )
+
+    return {
+        "rules_written": rules_written,
+        "rules_removed": rules_removed,
+        "manifest_id": manifest_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Settings helper (used by run_once and run_loop)
+# ---------------------------------------------------------------------------
+
+
+class FleetClientSettings:
+    """Thin settings bag populated from env vars.
+
+    Attributes:
+        manifest_url:    Full URL to the manifest endpoint.
+        hmac_key:        Raw HMAC key bytes (hex-decoded from FLEET_HMAC_KEY).
+        rules_dir:       Local path where rule files are written.
+        bearer_token:    Optional bearer token for the manifest endpoint.
+    """
+
+    def __init__(
+        self,
+        manifest_url: str,
+        hmac_key: bytes,
+        rules_dir: str,
+        bearer_token: Optional[str] = None,
+    ) -> None:
+        self.manifest_url = manifest_url
+        self.hmac_key = hmac_key
+        self.rules_dir = rules_dir
+        self.bearer_token = bearer_token
+
+    @classmethod
+    def from_env(cls) -> "FleetClientSettings":
+        """Build settings from environment variables.
+
+        Required env vars:
+            FLEET_MANIFEST_URL   — full URL to the manifest endpoint
+            FLEET_HMAC_KEY       — hex-encoded HMAC key (32+ bytes recommended)
+            FLEET_RULES_DIR      — local directory for rule files (default /rules)
+
+        Optional:
+            FLEET_BEARER_TOKEN   — bearer token for auth-gated manager endpoints
+
+        Raises:
+            EnvironmentError: If required vars are missing or FLEET_HMAC_KEY
+                              is not valid hex.
+        """
+        missing = []
+
+        manifest_url = os.environ.get("FLEET_MANIFEST_URL", "")
+        if not manifest_url:
+            missing.append("FLEET_MANIFEST_URL")
+
+        hmac_key_hex = os.environ.get("FLEET_HMAC_KEY", "")
+        if not hmac_key_hex:
+            missing.append("FLEET_HMAC_KEY")
+
+        if missing:
+            raise EnvironmentError(
+                f"Missing required env vars: {', '.join(missing)}. "
+                "Set FLEET_MANIFEST_URL and FLEET_HMAC_KEY before starting the fleet client."
+            )
+
+        try:
+            hmac_key = bytes.fromhex(hmac_key_hex)
+        except ValueError as exc:
+            raise EnvironmentError(
+                f"FLEET_HMAC_KEY is not valid hex: {exc}"
+            ) from exc
+
+        rules_dir = os.environ.get("FLEET_RULES_DIR", "/rules")
+        bearer_token = os.environ.get("FLEET_BEARER_TOKEN") or None
+
+        return cls(
+            manifest_url=manifest_url,
+            hmac_key=hmac_key,
+            rules_dir=rules_dir,
+            bearer_token=bearer_token,
+        )
+
+
+# ---------------------------------------------------------------------------
+# run_once and run_loop
+# ---------------------------------------------------------------------------
+
+
+def run_once(settings: FleetClientSettings) -> dict:
+    """Fetch, verify, and apply the manifest in one synchronous call.
+
+    Args:
+        settings: A populated ``FleetClientSettings`` instance.
+
+    Returns:
+        Summary dict from ``verify_and_apply``.
+
+    Raises:
+        httpx.HTTPError:  On network or HTTP-level errors during fetch.
+        ValueError:       On HMAC signature failure.
+        OSError:          On file system errors during rule write.
+    """
+    manifest = fetch_manifest(
+        settings.manifest_url,
+        bearer_token=settings.bearer_token,
+    )
+    return verify_and_apply(manifest, settings.hmac_key, settings.rules_dir)
+
+
+async def run_loop(
+    settings: FleetClientSettings,
+    interval_seconds: int = 300,
+) -> None:
+    """Async polling loop that calls ``run_once`` every *interval_seconds*.
+
+    Errors (network, signature, I/O) are caught and logged; the loop
+    continues.  Cancellation (asyncio.CancelledError) propagates cleanly
+    so the caller can shut down via ``task.cancel()``.
+
+    Args:
+        settings:         Fleet client settings.
+        interval_seconds: Seconds between poll cycles (default 300 / 5 min).
+    """
+    log.info(
+        "Fleet client loop starting: url=%s rules_dir=%s interval=%ds",
+        settings.manifest_url,
+        settings.rules_dir,
+        interval_seconds,
+    )
+
+    while True:
+        try:
+            summary = run_once(settings)
+            log.info(
+                "Fleet apply OK — manifest_id=%s written=%d removed=%d",
+                summary["manifest_id"],
+                summary["rules_written"],
+                summary["rules_removed"],
+            )
+        except asyncio.CancelledError:
+            # CancelledError must propagate — do NOT catch it here
+            raise
+        except Exception as exc:  # noqa: BLE001
+            log.error(
+                "Fleet apply error (will retry in %ds): %s: %s",
+                interval_seconds,
+                type(exc).__name__,
+                exc,
+            )
+
+        try:
+            await asyncio.sleep(interval_seconds)
+        except asyncio.CancelledError:
+            log.info("Fleet client loop cancelled during sleep — exiting cleanly")
+            raise

--- a/agent/fleet_client_main.py
+++ b/agent/fleet_client_main.py
@@ -1,0 +1,111 @@
+"""
+CLI entrypoint for the shaferhund-fleet-client container.
+
+Reads env vars, validates them, then starts the async polling loop.
+Exits cleanly on SIGTERM / SIGINT.
+
+Run inside the container as:
+    python -m agent.fleet_client_main
+
+Or from the repo root (for dev/testing):
+    FLEET_MANIFEST_URL=http://... FLEET_HMAC_KEY=aa...aa python -m agent.fleet_client_main
+
+@decision DEC-FLEET-P6-003
+@title Fleet client entrypoint validates env then delegates to run_loop; SIGTERM exits cleanly
+@status accepted
+@rationale Container orchestrators (Kubernetes, Docker/Podman with restart policies) send
+           SIGTERM before SIGKILL. Converting SIGTERM to a CancelledError via asyncio's
+           signal handler lets run_loop's clean-exit path log a shutdown message before
+           the process exits. This avoids silent kills and gives the operator a log trail
+           of each clean shutdown vs. forced kill.
+"""
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+
+from agent.fleet_client import FleetClientSettings, run_loop
+
+# ---------------------------------------------------------------------------
+# Logging setup
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("fleet_client_main")
+
+
+# ---------------------------------------------------------------------------
+# SIGTERM / SIGINT handler
+# ---------------------------------------------------------------------------
+
+
+def _install_signal_handlers(loop: asyncio.AbstractEventLoop, main_task: asyncio.Task) -> None:
+    """Install SIGTERM + SIGINT handlers that cancel *main_task* cleanly."""
+
+    def _handle_signal(sig_name: str) -> None:
+        log.info("Received %s — cancelling fleet loop", sig_name)
+        main_task.cancel()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal, sig.name)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def _main_async() -> None:
+    """Async entry point: build settings, install handlers, run loop."""
+    # Validate env vars early — clear error messages before any async work.
+    try:
+        settings = FleetClientSettings.from_env()
+    except EnvironmentError as exc:
+        log.error("Configuration error: %s", exc)
+        sys.exit(1)
+
+    poll_interval_raw = os.environ.get("FLEET_POLL_INTERVAL_SECONDS", "300")
+    try:
+        poll_interval = int(poll_interval_raw)
+        if poll_interval < 1:
+            raise ValueError("must be >= 1")
+    except ValueError as exc:
+        log.error(
+            "FLEET_POLL_INTERVAL_SECONDS=%r is invalid (%s) — defaulting to 300s",
+            poll_interval_raw,
+            exc,
+        )
+        poll_interval = 300
+
+    log.info(
+        "Fleet client starting: manifest_url=%s rules_dir=%s poll_interval=%ds",
+        settings.manifest_url,
+        settings.rules_dir,
+        poll_interval,
+    )
+
+    loop = asyncio.get_running_loop()
+    main_task = asyncio.current_task()
+    assert main_task is not None  # always true inside async def
+
+    _install_signal_handlers(loop, main_task)
+
+    try:
+        await run_loop(settings, interval_seconds=poll_interval)
+    except asyncio.CancelledError:
+        log.info("Fleet client shut down cleanly")
+
+
+def main() -> None:
+    """Synchronous entry point called by __main__ and setuptools console_scripts."""
+    asyncio.run(_main_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/compose.fleet.yaml
+++ b/compose.fleet.yaml
@@ -1,0 +1,62 @@
+# compose.fleet.yaml — opt-in fleet client service
+#
+# Run alongside the default compose stack:
+#
+#   podman compose -f compose.yaml -f compose.fleet.yaml up
+#
+# The fleet client polls the manager's manifest endpoint, verifies the HMAC
+# signature, and writes rule files to a shared volume that the host's Wazuh
+# or Suricata agent can pick up.
+#
+# Required env vars (set in .env or pass -e):
+#   FLEET_MANIFEST_URL   — full URL to the manifest endpoint
+#                          default: http://shaferhund-agent:8000/fleet/manifest/edr-prod
+#   FLEET_HMAC_KEY       — hex-encoded HMAC key (same key configured on the manager
+#                          as SHAFERHUND_AUDIT_KEY). Generate: openssl rand -hex 32
+#   FLEET_BEARER_TOKEN   — bearer token for the manager's auth-gated endpoint
+#                          (omit only if the manager is in single-token mode and the
+#                           token is already handled by FLEET_MANIFEST_URL)
+#
+# Optional:
+#   FLEET_TAG                    — tag segment of the manifest URL (informational)
+#   FLEET_RULES_DIR              — path inside the container (default /rules)
+#   FLEET_POLL_INTERVAL_SECONDS  — seconds between manifest polls (default 300)
+#
+# The shaferhund_rules_fleet volume is a named volume scoped to this compose
+# project. In production, replace it with a bind mount to the Wazuh rules
+# directory on the host:
+#
+#   volumes:
+#     - /var/ossec/etc/rules:/rules
+#
+# @decision DEC-FLEET-P6-003
+# @title Fleet client in separate compose.fleet.yaml; not in compose.yaml
+# @status accepted
+# @rationale The fleet client runs on remote hosts alongside the remote Wazuh agent.
+#   The main compose.yaml stays at 5 services (unchanged from Phase 5). compose.fleet.yaml
+#   is an opt-in overlay for operators who want to test the full fleet pull locally.
+#   Precedent: compose.localstack.yaml from Phase 5 (DEC-CLOUD-013).
+
+services:
+  fleet-client:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.fleet-client
+    image: shaferhund-fleet-client:latest
+    container_name: shaferhund-fleet-client
+    restart: unless-stopped
+    environment:
+      - FLEET_MANIFEST_URL=${FLEET_MANIFEST_URL:-http://shaferhund-agent:8000/fleet/manifest/edr-prod}
+      - FLEET_TAG=${FLEET_TAG:-edr-prod}
+      - FLEET_HMAC_KEY=${FLEET_HMAC_KEY:-}
+      - FLEET_RULES_DIR=${FLEET_RULES_DIR:-/rules}
+      - FLEET_POLL_INTERVAL_SECONDS=${FLEET_POLL_INTERVAL_SECONDS:-300}
+      - FLEET_BEARER_TOKEN=${FLEET_BEARER_TOKEN:-}
+    volumes:
+      - shaferhund_rules_fleet:/rules
+    networks:
+      - default
+
+volumes:
+  shaferhund_rules_fleet:
+    driver: local

--- a/docker/Dockerfile.fleet-client
+++ b/docker/Dockerfile.fleet-client
@@ -1,0 +1,51 @@
+# Shaferhund Fleet Client — minimal standalone container (REQ-P0-P6-002)
+#
+# @decision DEC-FLEET-P6-003
+# @title Fleet client is a separate minimal image; not in compose.yaml
+# @status accepted
+# @rationale The fleet client runs on *remote* hosts alongside the operator's Wazuh agent,
+#   not inside the local manager-side stack. It only needs httpx + the HMAC verification
+#   logic from agent/fleet.py. We copy only the four files required (agent/__init__.py,
+#   agent/models.py, agent/fleet.py, agent/fleet_client.py, agent/fleet_client_main.py)
+#   so the image contains no FastAPI, no SQLite write paths, no argon2, no orchestrator
+#   code. Smaller image = smaller attack surface. See compose.fleet.yaml for deployment.
+#
+# Build:
+#   podman build -f docker/Dockerfile.fleet-client -t shaferhund-fleet-client:latest .
+#
+# Run (standalone):
+#   podman run --rm \
+#     -e FLEET_MANIFEST_URL=http://manager:8000/fleet/manifest/edr-prod \
+#     -e FLEET_HMAC_KEY=$(cat /etc/shaferhund/fleet.key) \
+#     -e FLEET_BEARER_TOKEN=<operator-token> \
+#     -v /var/ossec/etc/rules:/rules \
+#     shaferhund-fleet-client:latest
+
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+# Only the runtime dependency the client needs — httpx for manifest fetch.
+# agent/fleet.py and agent/models.py are stdlib-only (no extra deps required).
+RUN pip install --no-cache-dir "httpx>=0.28,<1"
+
+# Copy only the files needed — no FastAPI, no argon2, no orchestrator code.
+COPY agent/__init__.py /app/agent/__init__.py
+COPY agent/models.py   /app/agent/models.py
+COPY agent/fleet.py    /app/agent/fleet.py
+COPY agent/fleet_client.py      /app/agent/fleet_client.py
+COPY agent/fleet_client_main.py /app/agent/fleet_client_main.py
+
+# Non-root user for container security best practice.
+# The /rules mount is owned by fleet so the process can write rule files.
+RUN useradd -m -u 1000 fleet && \
+    mkdir -p /rules && chown fleet:fleet /rules
+
+USER fleet
+
+# Default poll interval — override via FLEET_POLL_INTERVAL_SECONDS env var.
+ENV FLEET_POLL_INTERVAL_SECONDS=300
+ENV FLEET_RULES_DIR=/rules
+
+CMD ["python", "-m", "agent.fleet_client_main"]

--- a/docs/fleet-client-deployment.md
+++ b/docs/fleet-client-deployment.md
@@ -1,0 +1,174 @@
+# Fleet Client Deployment Guide
+
+The Shaferhund fleet client is a minimal container that polls the manager's
+manifest endpoint, verifies the HMAC signature, and writes rule files to a
+local mount. The host's Wazuh or Suricata agent picks up the files from that
+mount without any manual YAML copying.
+
+This is the client side of the fleet distribution system introduced in Phase 6
+(REQ-P0-P6-002). The server side — the signed manifest endpoint — is built into
+the existing `shaferhund-agent` container.
+
+---
+
+## What the fleet client does
+
+1. Every `FLEET_POLL_INTERVAL_SECONDS` (default 300), it sends a GET request to
+   `FLEET_MANIFEST_URL`.
+2. It verifies the HMAC-SHA256 signature on the manifest using `FLEET_HMAC_KEY`.
+   A tampered or wrong-key manifest is rejected and no files are touched.
+3. For each rule in the manifest it writes `<rules_dir>/<rule_uuid>.<ext>` where
+   the extension matches the rule type (`.yar` for YARA, `.yml` for Sigma, `.xml`
+   for Wazuh).
+4. Any file in `rules_dir` that is NOT in the current manifest is deleted (stale
+   cleanup — when a rule is untagged on the manager, the client removes it locally
+   on the next pull).
+5. Every apply cycle is logged to stdout with the manifest ID, rules written, and
+   rules removed. Errors are logged and retried on the next interval.
+
+---
+
+## Required environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `FLEET_MANIFEST_URL` | Full URL to the manager's manifest endpoint, e.g. `http://shaferhund-agent:8000/fleet/manifest/edr-prod` |
+| `FLEET_HMAC_KEY` | Hex-encoded HMAC key. Must match the manager's `SHAFERHUND_AUDIT_KEY`. Generate with: `openssl rand -hex 32` |
+| `FLEET_BEARER_TOKEN` | Bearer token for the manager's auth-gated endpoint. Obtain via `POST /auth/login` or `POST /auth/tokens` on the manager. |
+
+## Optional environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FLEET_RULES_DIR` | `/rules` | Local directory where rule files are written |
+| `FLEET_POLL_INTERVAL_SECONDS` | `300` | Seconds between manifest polls |
+
+---
+
+## HMAC key generation
+
+The HMAC key must match the key configured on the manager (`SHAFERHUND_AUDIT_KEY`).
+Generate a 32-byte key and distribute it out-of-band (Kubernetes secret, Vault, etc.):
+
+```bash
+openssl rand -hex 32
+# example output: a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2
+```
+
+Set this value as `SHAFERHUND_AUDIT_KEY` on the manager and as `FLEET_HMAC_KEY` on
+each fleet client. A mismatched key causes every manifest fetch to fail signature
+verification — the client logs the error and retries on the next interval.
+
+---
+
+## Deployment with compose.fleet.yaml
+
+The fleet client is an opt-in overlay, separate from the main `compose.yaml`
+(which stays at 5 services). Run it alongside the default stack:
+
+```bash
+# Start the manager stack (if not already running)
+podman compose -f compose.yaml up -d
+
+# Start the fleet client overlay
+podman compose -f compose.yaml -f compose.fleet.yaml up -d fleet-client
+```
+
+Set required env vars in your `.env` file (never commit this file):
+
+```bash
+FLEET_MANIFEST_URL=http://shaferhund-agent:8000/fleet/manifest/edr-prod
+FLEET_HMAC_KEY=<output of openssl rand -hex 32>
+FLEET_BEARER_TOKEN=<token from POST /auth/login or POST /auth/tokens>
+```
+
+The `shaferhund_rules_fleet` named volume holds the rule files. In production,
+replace it with a bind mount to your Wazuh rules directory:
+
+```yaml
+# in compose.fleet.yaml or a local override:
+services:
+  fleet-client:
+    volumes:
+      - /var/ossec/etc/rules:/rules
+```
+
+---
+
+## How to scope a remote endpoint (FLEET_TAG)
+
+`FLEET_TAG` is the tag segment of the manifest URL. Tags are applied on the
+manager via `POST /rules/{rule_id}/tag` (operator role required). For example,
+to scope rules for the EDR production group:
+
+```bash
+# On the manager — tag a deployed rule for the edr-prod group
+curl -X POST http://manager:8000/rules/<rule-id>/tag \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"tag": "edr-prod"}'
+
+# On the fleet client — set the URL to match the tag
+FLEET_MANIFEST_URL=http://shaferhund-agent:8000/fleet/manifest/edr-prod
+```
+
+The manifest endpoint filters to only deployed rules carrying that tag. Rules
+untagged from the group disappear from the next manifest and the client removes
+their files on the next poll.
+
+---
+
+## Standalone container (without compose)
+
+```bash
+podman run -d --name shaferhund-fleet-client \
+  -e FLEET_MANIFEST_URL=http://manager:8000/fleet/manifest/edr-prod \
+  -e FLEET_HMAC_KEY=$(cat /etc/shaferhund/fleet.key) \
+  -e FLEET_BEARER_TOKEN=<token> \
+  -e FLEET_POLL_INTERVAL_SECONDS=60 \
+  -v /var/ossec/etc/rules:/rules \
+  --restart unless-stopped \
+  shaferhund-fleet-client:latest
+```
+
+---
+
+## Troubleshooting
+
+**Signature failures**
+```
+Fleet apply error: Manifest signature verification failed for manifest_id='abc123...'
+```
+Cause: `FLEET_HMAC_KEY` does not match the manager's `SHAFERHUND_AUDIT_KEY`.
+Fix: Ensure both values are identical hex strings. Regenerate and redistribute
+if the key has been rotated on the manager.
+
+**Network errors / connection refused**
+```
+Fleet apply error: httpx.ConnectError: ...
+```
+Cause: The manager is unreachable at `FLEET_MANIFEST_URL`.
+Fix: Check network connectivity, DNS resolution, and that the manager container
+is running. The client retries automatically after `FLEET_POLL_INTERVAL_SECONDS`.
+
+**401 / 403 from manifest endpoint**
+```
+Fleet apply error: httpx.HTTPStatusError: 401 ...
+```
+Cause: `FLEET_BEARER_TOKEN` is missing, expired, or insufficient role.
+Fix: Issue a new token on the manager (`POST /auth/login` or `POST /auth/tokens`
+with operator role). Tokens issued via `/auth/tokens` can have longer expiry
+for service accounts.
+
+**Rules directory permission denied**
+```
+Fleet apply error: PermissionError: [Errno 13] Permission denied: '/rules/...'
+```
+Cause: The `fleet` user (uid 1000) cannot write to the mounted rules directory.
+Fix: Ensure the host directory is writable by uid 1000, or run the container
+with `--user root` (not recommended in production).
+
+**No rules written despite manifest showing rules**
+Check that the rules on the manager are both **deployed** (`POST /rules/{id}/deploy`)
+AND **tagged** with the correct tag (`POST /rules/{id}/tag` with the matching tag
+string). Draft rules (deployed=0) never appear in manifests per DEC-FLEET-P6-002.

--- a/tests/integration/test_fleet_client_integration.py
+++ b/tests/integration/test_fleet_client_integration.py
@@ -1,0 +1,243 @@
+"""
+Integration tests for the fleet client end-to-end path (Phase 6 Wave B2).
+
+Exercises the full path: manager manifest endpoint → fetch_manifest →
+verify_and_apply → rule files on disk. Uses a FastAPI TestClient against the
+real agent.main app so no external process is required.
+
+Unlike the LocalStack integration tests (test_cloudtrail_localstack.py), this
+test is self-contained — it does not require any running service. The only
+"integration" aspect is that it exercises the real HTTP layer (TestClient)
+rather than mocking httpx.
+
+Gated by -m integration so the default pytest suite never runs this:
+    pytest -m integration tests/integration/
+
+@decision DEC-FLEET-P6-005
+@title LocalStack-style integration test; gated by -m integration; no external service needed
+@status accepted
+@rationale The fleet client's unit tests mock httpx. This integration test uses a real
+           FastAPI TestClient so it exercises the full request → response path including
+           auth, HMAC signing, and the manifest route. It is in tests/integration/ and
+           marked with @pytest.mark.integration so the default suite (addopts = -m
+           "not integration") never picks it up. Consistent with DEC-CLOUD-013.
+"""
+
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Integration marker — guards for skip when running default suite
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_HMAC_KEY_HEX = "aa" * 32
+_HMAC_KEY = bytes.fromhex(_HMAC_KEY_HEX)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def fleet_env(tmp_path_factory):
+    """Set env vars + bootstrap a TestClient against agent.main.
+
+    Yields (client, admin_token, rules_dir_path).
+    """
+    db_path = str(tmp_path_factory.mktemp("fleet_int") / "integration.db")
+
+    # Remove any stale DB from a previous run
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    # Set env BEFORE importing agent.main so Settings picks them up
+    os.environ["DB_PATH"] = db_path
+    os.environ["ANTHROPIC_API_KEY"] = "sk-ant-test-dummy"
+    os.environ["SHAFERHUND_AUTH_MODE"] = "multi"
+    os.environ["SHAFERHUND_AUDIT_KEY"] = _HMAC_KEY_HEX
+    os.environ["SHAFERHUND_BOOTSTRAP_ADMIN_USERNAME"] = "admin"
+    os.environ["SHAFERHUND_BOOTSTRAP_ADMIN_PASSWORD"] = "adminpw123"
+
+    from fastapi.testclient import TestClient
+    from agent.main import app
+
+    with TestClient(app) as client:
+        # Login as bootstrap admin
+        resp = client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "adminpw123"},
+        )
+        assert resp.status_code == 200, f"Login failed: {resp.text}"
+        admin_token = resp.json()["token"]
+
+        rules_dir = tmp_path_factory.mktemp("rules")
+        yield client, admin_token, rules_dir
+
+
+# ---------------------------------------------------------------------------
+# Helper: seed a deployed+tagged rule via the DB directly
+# ---------------------------------------------------------------------------
+
+def _seed_rule_direct(db_path: str, rule_id: str, tag: str, rule_type: str = "yara") -> None:
+    """Insert a deployed rule + tag it directly in the DB."""
+    from agent.models import insert_rule, tag_rule
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    # Idempotent — skip if already exists
+    existing = conn.execute("SELECT id FROM rules WHERE id=?", (rule_id,)).fetchone()
+    if existing is None:
+        conn.execute(
+            "INSERT INTO rules (id, cluster_id, rule_type, rule_content, syntax_valid, deployed)"
+            " VALUES (?, NULL, ?, ?, 1, 1)",
+            (rule_id, rule_type, f"rule {rule_id} {{}}"),
+        )
+        conn.commit()
+    tag_rule(conn, rule_id, tag)
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: run_once writes rule file for a tagged+deployed rule
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_fleet_client_run_once_writes_rule(fleet_env):
+    """Seed a deployed YARA rule, fetch manifest via TestClient, verify+apply.
+
+    Asserts: rule file written to tmp rules_dir with .yar extension.
+    """
+    client, admin_token, rules_dir = fleet_env
+    db_path = os.environ["DB_PATH"]
+    rule_id = "integ-test-rule-001"
+    tag = "edr-prod"
+
+    # Seed rule directly in DB
+    _seed_rule_direct(db_path, rule_id, tag, rule_type="yara")
+
+    # Fetch the manifest via the TestClient URL
+    manifest_resp = client.get(
+        f"/fleet/manifest/{tag}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert manifest_resp.status_code == 200, f"Manifest fetch failed: {manifest_resp.text}"
+    manifest = manifest_resp.json()
+
+    # Verify the rule is in the manifest
+    rule_ids = [r["id"] for r in manifest.get("rules", [])]
+    assert rule_id in rule_ids, f"Expected {rule_id!r} in manifest rules; got {rule_ids}"
+
+    # verify_and_apply against the tmp rules_dir
+    from agent.fleet_client import verify_and_apply
+    summary = verify_and_apply(manifest, _HMAC_KEY, str(rules_dir))
+
+    assert summary["rules_written"] >= 1
+    assert summary["manifest_id"] == manifest["manifest_id"]
+    assert Path(rules_dir / f"{rule_id}.yar").exists(), (
+        f"Expected {rule_id}.yar in {list(rules_dir.iterdir())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Untagged rule is removed from rules_dir on next pull
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_fleet_client_stale_rule_removed_when_untagged(fleet_env):
+    """After a rule is untagged on the manager, the next apply removes the file.
+
+    Sequence:
+    1. Seed rule-002 tagged edr-prod2 — verify_and_apply writes it.
+    2. Untag rule-002 from edr-prod2 — manifest becomes empty.
+    3. verify_and_apply again — file for rule-002 is removed.
+    """
+    client, admin_token, rules_dir = fleet_env
+    db_path = os.environ["DB_PATH"]
+    rule_id = "integ-test-rule-002"
+    tag = "edr-prod2"
+
+    # Step 1: seed + apply
+    _seed_rule_direct(db_path, rule_id, tag, rule_type="sigma")
+
+    manifest_resp = client.get(
+        f"/fleet/manifest/{tag}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert manifest_resp.status_code == 200
+    manifest = manifest_resp.json()
+    assert any(r["id"] == rule_id for r in manifest.get("rules", [])), (
+        "Rule should appear in manifest before untagging"
+    )
+
+    from agent.fleet_client import verify_and_apply
+
+    # Write the rule file
+    local_rules = rules_dir / "stale_test"
+    local_rules.mkdir(exist_ok=True)
+    verify_and_apply(manifest, _HMAC_KEY, str(local_rules))
+    assert Path(local_rules / f"{rule_id}.yml").exists()
+
+    # Step 2: untag via DB directly (no untag route exists yet — model layer)
+    conn = sqlite3.connect(db_path)
+    conn.execute("DELETE FROM rule_tags WHERE rule_id=? AND tag=?", (rule_id, tag))
+    conn.commit()
+    conn.close()
+
+    # Step 3: fetch manifest again — rule should be gone; apply removes file
+    manifest_resp2 = client.get(
+        f"/fleet/manifest/{tag}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert manifest_resp2.status_code == 200
+    manifest2 = manifest_resp2.json()
+    assert not any(r["id"] == rule_id for r in manifest2.get("rules", [])), (
+        "Untagged rule should not appear in manifest"
+    )
+
+    summary2 = verify_and_apply(manifest2, _HMAC_KEY, str(local_rules))
+    assert summary2["rules_removed"] >= 1
+    assert not Path(local_rules / f"{rule_id}.yml").exists(), (
+        "Stale rule file should have been removed after untagging"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Tampered manifest is rejected; no files are written
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_fleet_client_tampered_manifest_rejected(fleet_env):
+    """Manifest with corrupted signature is rejected before any file write."""
+    client, admin_token, rules_dir = fleet_env
+    db_path = os.environ["DB_PATH"]
+    _seed_rule_direct(db_path, "integ-test-rule-003", "tamper-tag", rule_type="yara")
+
+    manifest_resp = client.get(
+        "/fleet/manifest/tamper-tag",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert manifest_resp.status_code == 200
+    manifest = manifest_resp.json()
+
+    # Tamper the signature
+    manifest["signature"] = "0" * 64
+
+    local_rules = rules_dir / "tamper_test"
+    local_rules.mkdir(exist_ok=True)
+
+    from agent.fleet_client import verify_and_apply
+    with pytest.raises(ValueError, match="signature verification failed"):
+        verify_and_apply(manifest, _HMAC_KEY, str(local_rules))
+
+    # No files should have been written
+    written = list(local_rules.iterdir())
+    assert written == [], f"No files should be written after rejection; got {written}"

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -1,0 +1,390 @@
+"""
+Unit tests for agent/fleet_client.py (Phase 6 Wave B2, REQ-P0-P6-002).
+
+Tests cover: fetch_manifest, verify_and_apply, run_once, run_loop,
+FleetClientSettings.from_env.
+
+All tests run without an external server — httpx is mocked via
+unittest.mock.patch for the fetch_manifest tests.  verify_and_apply and
+run_once use real HMAC keys and real file I/O against tmp_path.
+
+# @mock-exempt: httpx.Client is an external HTTP boundary — mocking it is the
+# appropriate approach for unit tests. All internal logic (HMAC verification,
+# file writes, stale cleanup) is tested with real I/O.
+"""
+
+import asyncio
+import os
+import unittest.mock as mock
+from pathlib import Path
+
+import httpx
+import pytest
+
+from agent.fleet import build_manifest, sign_manifest, canonical_manifest_body
+from agent.fleet_client import (
+    FleetClientSettings,
+    fetch_manifest,
+    run_loop,
+    run_once,
+    verify_and_apply,
+)
+from agent.models import init_db, insert_rule, tag_rule
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_KEY = bytes.fromhex("aa" * 32)
+_WRONG_KEY = bytes.fromhex("bb" * 32)
+_FIXED_TS = "2026-04-25T16:30:00+00:00"
+_MANIFEST_URL = "http://manager:8000/fleet/manifest/edr-prod"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_valid_manifest(rules: list[dict] | None = None) -> dict:
+    """Build a properly signed manifest dict without a real DB."""
+    if rules is None:
+        rules = []
+    canon = canonical_manifest_body(1, "edr-prod", _FIXED_TS, rules)
+    sig = sign_manifest(_KEY, canon)
+    import hashlib
+    manifest_id = hashlib.sha256(canon).hexdigest()
+    return {
+        "version": 1,
+        "manifest_id": manifest_id,
+        "tag": "edr-prod",
+        "generated_at": _FIXED_TS,
+        "rules": rules,
+        "signature": sig,
+    }
+
+
+def _make_db_manifest(conn, tag: str = "edr-prod") -> dict:
+    """Build a signed manifest from a real DB connection."""
+    return build_manifest(conn, tag, _KEY, generated_at=_FIXED_TS)
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    db = init_db(str(tmp_path / "test.db"))
+    yield db
+    db.close()
+
+
+def _seed_rule(conn, rule_id: str = "rule-001", tag: str = "edr-prod", rule_type: str = "yara") -> str:
+    insert_rule(
+        conn,
+        rule_id=rule_id,
+        cluster_id=None,
+        rule_type=rule_type,
+        rule_content=f"rule {rule_id} {{}}",
+        syntax_valid=True,
+    )
+    conn.execute("UPDATE rules SET deployed = 1 WHERE id = ?", (rule_id,))
+    conn.commit()
+    tag_rule(conn, rule_id, tag)
+    return rule_id
+
+
+@pytest.fixture()
+def settings(tmp_path) -> FleetClientSettings:
+    return FleetClientSettings(
+        manifest_url=_MANIFEST_URL,
+        hmac_key=_KEY,
+        rules_dir=str(tmp_path / "rules"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch_manifest
+# ---------------------------------------------------------------------------
+
+def test_fetch_manifest_success():
+    """Mock 200 response — returns parsed dict."""
+    expected = {"version": 1, "rules": [], "signature": "abc"}
+    with mock.patch("agent.fleet_client.httpx.Client") as mock_client_cls:
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = expected
+        mock_resp.raise_for_status = mock.MagicMock()
+        mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+
+        result = fetch_manifest(_MANIFEST_URL)
+
+    assert result == expected
+    mock_resp.raise_for_status.assert_called_once()
+
+
+def test_fetch_manifest_with_bearer_token():
+    """Bearer token is sent as Authorization header."""
+    with mock.patch("agent.fleet_client.httpx.Client") as mock_client_cls:
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {}
+        mock_resp.raise_for_status = mock.MagicMock()
+        mock_get = mock_client_cls.return_value.__enter__.return_value.get
+        mock_get.return_value = mock_resp
+
+        fetch_manifest(_MANIFEST_URL, bearer_token="my-secret-token")
+
+    _call_kwargs = mock_get.call_args
+    sent_headers = _call_kwargs.kwargs.get("headers") or _call_kwargs.args[1] if len(_call_kwargs.args) > 1 else {}
+    # Verify the Authorization header was passed (either via positional or keyword)
+    all_kwargs = mock_get.call_args[1] if mock_get.call_args[1] else {}
+    headers = all_kwargs.get("headers", {})
+    assert headers.get("Authorization") == "Bearer my-secret-token"
+
+
+def test_fetch_manifest_4xx_raises():
+    """4xx response raises httpx.HTTPStatusError."""
+    with mock.patch("agent.fleet_client.httpx.Client") as mock_client_cls:
+        mock_resp = mock.MagicMock()
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401 Unauthorized",
+            request=mock.MagicMock(),
+            response=mock.MagicMock(),
+        )
+        mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+
+        with pytest.raises(httpx.HTTPStatusError):
+            fetch_manifest(_MANIFEST_URL)
+
+
+# ---------------------------------------------------------------------------
+# verify_and_apply
+# ---------------------------------------------------------------------------
+
+def test_verify_and_apply_invalid_signature_raises(tmp_path):
+    """Tampered signature → ValueError before any file is written."""
+    manifest = _make_valid_manifest()
+    manifest["signature"] = "0" * 64  # corrupt
+
+    rules_dir = str(tmp_path / "rules")
+    with pytest.raises(ValueError, match="signature verification failed"):
+        verify_and_apply(manifest, _KEY, rules_dir)
+
+    # No files should have been written
+    assert not Path(rules_dir).exists() or list(Path(rules_dir).iterdir()) == []
+
+
+def test_verify_and_apply_wrong_key_raises(tmp_path):
+    """Wrong key → ValueError, no files written."""
+    manifest = _make_valid_manifest()
+    rules_dir = str(tmp_path / "rules")
+    with pytest.raises(ValueError, match="signature verification failed"):
+        verify_and_apply(manifest, _WRONG_KEY, rules_dir)
+
+
+def test_verify_and_apply_writes_rule_files(tmp_path):
+    """Valid manifest with 2 rules → 2 files with correct extensions."""
+    rules = [
+        {"id": "rule-yara-001", "rule_type": "yara", "name": "c1", "content": "rule yara_001 {}", "syntax_valid": 1},
+        {"id": "rule-sigma-002", "rule_type": "sigma", "name": "c2", "content": "title: Sigma", "syntax_valid": 1},
+    ]
+    manifest = _make_valid_manifest(rules)
+    rules_dir = str(tmp_path / "rules")
+
+    summary = verify_and_apply(manifest, _KEY, rules_dir)
+
+    assert summary["rules_written"] == 2
+    assert summary["rules_removed"] == 0
+    assert Path(rules_dir, "rule-yara-001.yar").exists()
+    assert Path(rules_dir, "rule-sigma-002.yml").exists()
+    assert Path(rules_dir, "rule-yara-001.yar").read_text() == "rule yara_001 {}"
+    assert Path(rules_dir, "rule-sigma-002.yml").read_text() == "title: Sigma"
+
+
+def test_verify_and_apply_removes_stale_files(tmp_path):
+    """Stale file in rules_dir not in manifest → removed after apply."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    stale = rules_dir / "stale-rule.yar"
+    stale.write_text("rule stale {}")
+
+    manifest = _make_valid_manifest()  # empty rules list
+    summary = verify_and_apply(manifest, _KEY, str(rules_dir))
+
+    assert summary["rules_removed"] == 1
+    assert not stale.exists()
+
+
+def test_verify_and_apply_returns_summary(tmp_path):
+    """Summary dict has required keys with correct types."""
+    manifest = _make_valid_manifest()
+    summary = verify_and_apply(manifest, _KEY, str(tmp_path / "rules"))
+
+    assert "rules_written" in summary
+    assert "rules_removed" in summary
+    assert "manifest_id" in summary
+    assert isinstance(summary["rules_written"], int)
+    assert isinstance(summary["rules_removed"], int)
+    assert isinstance(summary["manifest_id"], str)
+
+
+def test_verify_and_apply_creates_rules_dir(tmp_path):
+    """rules_dir is created if it does not exist."""
+    rules_dir = str(tmp_path / "nested" / "rules")
+    manifest = _make_valid_manifest()
+    verify_and_apply(manifest, _KEY, rules_dir)
+    assert Path(rules_dir).exists()
+
+
+def test_verify_and_apply_wazuh_extension(tmp_path):
+    """Wazuh rule type gets .xml extension."""
+    rules = [{"id": "rule-wazuh-001", "rule_type": "wazuh", "name": "", "content": "<rule/>", "syntax_valid": 1}]
+    manifest = _make_valid_manifest(rules)
+    summary = verify_and_apply(manifest, _KEY, str(tmp_path / "rules"))
+    assert Path(tmp_path / "rules" / "rule-wazuh-001.xml").exists()
+    assert summary["rules_written"] == 1
+
+
+def test_verify_and_apply_unknown_rule_type_extension(tmp_path):
+    """Unknown rule type gets default .rule extension."""
+    rules = [{"id": "rule-unknown-001", "rule_type": "custom", "name": "", "content": "data", "syntax_valid": 0}]
+    manifest = _make_valid_manifest(rules)
+    summary = verify_and_apply(manifest, _KEY, str(tmp_path / "rules"))
+    assert Path(tmp_path / "rules" / "rule-unknown-001.rule").exists()
+    assert summary["rules_written"] == 1
+
+
+def test_verify_and_apply_only_removes_managed_extensions(tmp_path):
+    """Non-managed files (e.g. .conf) in rules_dir are not removed."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    conf_file = rules_dir / "local_rules.conf"
+    conf_file.write_text("# keep me")
+
+    manifest = _make_valid_manifest()  # empty rules list
+    summary = verify_and_apply(manifest, _KEY, str(rules_dir))
+
+    assert conf_file.exists(), "Non-managed .conf file should not be removed"
+    assert summary["rules_removed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# run_once
+# ---------------------------------------------------------------------------
+
+def test_run_once_full_path(tmp_path, conn):
+    """run_once fetches and applies; rule file appears in rules_dir."""
+    _seed_rule(conn, "rule-001", "edr-prod", "yara")
+    manifest = _make_db_manifest(conn, "edr-prod")
+
+    with mock.patch("agent.fleet_client.fetch_manifest", return_value=manifest):
+        settings = FleetClientSettings(
+            manifest_url=_MANIFEST_URL,
+            hmac_key=_KEY,
+            rules_dir=str(tmp_path / "rules"),
+        )
+        summary = run_once(settings)
+
+    assert summary["rules_written"] == 1
+    assert Path(tmp_path / "rules" / "rule-001.yar").exists()
+
+
+# ---------------------------------------------------------------------------
+# run_loop
+# ---------------------------------------------------------------------------
+
+def test_run_loop_cancellation(tmp_path):
+    """Task cancellation exits cleanly — no unhandled exceptions."""
+    manifest = _make_valid_manifest()
+
+    async def _run():
+        with mock.patch("agent.fleet_client.fetch_manifest", return_value=manifest):
+            settings = FleetClientSettings(
+                manifest_url=_MANIFEST_URL,
+                hmac_key=_KEY,
+                rules_dir=str(tmp_path / "rules"),
+            )
+            task = asyncio.create_task(run_loop(settings, interval_seconds=10))
+            # Let one iteration start then cancel
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass  # expected — clean exit
+
+    asyncio.run(_run())
+
+
+def test_run_loop_handles_fetch_error_gracefully(tmp_path):
+    """Fetch error on first iteration — loop survives and second iteration succeeds."""
+    manifest = _make_valid_manifest()
+    call_count = 0
+
+    def _fetch_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ConnectError("connection refused")
+        return manifest
+
+    async def _run():
+        with mock.patch("agent.fleet_client.fetch_manifest", side_effect=_fetch_side_effect):
+            settings = FleetClientSettings(
+                manifest_url=_MANIFEST_URL,
+                hmac_key=_KEY,
+                rules_dir=str(tmp_path / "rules"),
+            )
+            task = asyncio.create_task(run_loop(settings, interval_seconds=0))
+            # Wait long enough for 2 iterations at 0s interval
+            await asyncio.sleep(0.2)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    asyncio.run(_run())
+    assert call_count >= 2, f"Expected >=2 fetch calls, got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# FleetClientSettings.from_env
+# ---------------------------------------------------------------------------
+
+def test_settings_from_env_success(monkeypatch, tmp_path):
+    """from_env reads all required + optional vars correctly."""
+    monkeypatch.setenv("FLEET_MANIFEST_URL", "http://manager:8000/fleet/manifest/edr-prod")
+    monkeypatch.setenv("FLEET_HMAC_KEY", "aa" * 32)
+    monkeypatch.setenv("FLEET_RULES_DIR", str(tmp_path / "rules"))
+    monkeypatch.setenv("FLEET_BEARER_TOKEN", "tok-123")
+
+    settings = FleetClientSettings.from_env()
+
+    assert settings.manifest_url == "http://manager:8000/fleet/manifest/edr-prod"
+    assert settings.hmac_key == bytes.fromhex("aa" * 32)
+    assert settings.rules_dir == str(tmp_path / "rules")
+    assert settings.bearer_token == "tok-123"
+
+
+def test_settings_from_env_missing_required(monkeypatch):
+    """Missing required env vars → EnvironmentError with clear message."""
+    monkeypatch.delenv("FLEET_MANIFEST_URL", raising=False)
+    monkeypatch.delenv("FLEET_HMAC_KEY", raising=False)
+
+    with pytest.raises(EnvironmentError, match="FLEET_MANIFEST_URL"):
+        FleetClientSettings.from_env()
+
+
+def test_settings_from_env_invalid_hex(monkeypatch):
+    """Invalid hex in FLEET_HMAC_KEY → EnvironmentError."""
+    monkeypatch.setenv("FLEET_MANIFEST_URL", "http://manager/fleet/manifest/edr-prod")
+    monkeypatch.setenv("FLEET_HMAC_KEY", "not-valid-hex!")
+
+    with pytest.raises(EnvironmentError, match="not valid hex"):
+        FleetClientSettings.from_env()
+
+
+def test_settings_from_env_optional_bearer_none(monkeypatch):
+    """Missing FLEET_BEARER_TOKEN → bearer_token is None (not empty string)."""
+    monkeypatch.setenv("FLEET_MANIFEST_URL", "http://manager/fleet/manifest/edr-prod")
+    monkeypatch.setenv("FLEET_HMAC_KEY", "aa" * 32)
+    monkeypatch.delenv("FLEET_BEARER_TOKEN", raising=False)
+
+    settings = FleetClientSettings.from_env()
+    assert settings.bearer_token is None


### PR DESCRIPTION
## Scope (Wave B2 — REQ-P0-P6-002)

Fleet client side: container + entrypoint + integration tests. Reuses Wave A4's `verify_manifest` from `agent/fleet.py` (no duplication). Closes #74.

**7 NEW files, 0 modified.** `agent/fleet.py` untouched (verified: empty diff, Wave A4's 61 tests pass unchanged).

- `agent/fleet_client.py` — `fetch_manifest`, `verify_and_apply`, `run_once`, `run_loop`
- `agent/fleet_client_main.py` — CLI entrypoint
- `docker/Dockerfile.fleet-client` — `python:3.12-slim` + httpx, 5 agent files copied, non-root user
- `compose.fleet.yaml` — opt-in, mirrors Phase 5 #58 LocalStack pattern
- `docs/fleet-client-deployment.md` — operator guide (FLEET_* env vars, `openssl rand -hex 32`, compose invocation)
- `tests/test_fleet_client.py` — 19 unit tests
- `tests/integration/test_fleet_client_integration.py` — 3 integration tests gated by `-m integration`

## Verification

**581 passed / 1 skipped / 0 failed** (+21 unit tests over Wave B1's 560). 3 integration tests pass via `-m integration`; default suite correctly excludes them. TOOLS still 9.

### Critical safety property: no partial-write attack vector

Tampered manifests (content tamper + wrong key) are REJECTED **before any file is written**. Verified live:
- `rules_dir` remains EMPTY through both tamper attempts
- Only after a clean apply does the rule file appear
- Stale rule cleanup: untag a rule → next apply reports `rules_removed=1`, file disappears
- `run_loop` catches real `httpx.ConnectError` and continues; clean `CancelledError` exit on stop

### Wave A4 regression check

`agent/fleet.py` empty diff. 61 Wave A4 tests pass unchanged. Reuse, not duplication.

### DEC annotations

DEC-FLEET-P6-001 / 003 / 005 present.

## Operator follow-up (non-blocking)

Docker image build not exercised — no container runtime in implementer/tester env. Dockerfile structure verified visually; follows `Dockerfile.redteam-target` pattern. **Recommend operator-side `podman build -f docker/Dockerfile.fleet-client` smoke test before deploying to production agents.**

Closes #74