### PR TITLE
feat(#75): /health auth.* + fleet.* blocks; /metrics per-role counters (REQ-P1-P6-005)

### DIFF
--- a/agent/audit.py
+++ b/agent/audit.py
@@ -77,10 +77,16 @@ _BODY_EXCERPT_MAX = 200
 # HTTP methods that are audited unconditionally (mutating requests).
 _AUDITED_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
-# GET paths that are audited because they expose admin-only data.
-# These are exact-match strings.  The middleware checks startswith for
-# prefix-based routes (e.g. /audit is the prefix for /audit/verify).
-_AUDITED_GET_PREFIXES = frozenset({"/audit"})
+# GET paths that are audited because they expose admin-only data or
+# represent security-relevant distribution events.
+# The middleware checks startswith for prefix-based routes
+# (e.g. /audit is the prefix for /audit/verify).
+#
+# Phase 6 Wave B3 (REQ-P1-P6-005, DEC-OBSERVABILITY-P6-001): /fleet/manifest/
+# is added so every manifest fetch is recorded in audit_log.  The audit log
+# is the source of truth for fleet observability counters in /health and
+# /metrics — no separate in-memory counter is maintained (DEC-OBSERVABILITY-P6-001).
+_AUDITED_GET_PREFIXES = frozenset({"/audit", "/fleet/manifest/"})
 
 
 # ---------------------------------------------------------------------------

--- a/agent/main.py
+++ b/agent/main.py
@@ -184,6 +184,12 @@ from .models import (
     update_user_password,
 )
 from .auth import generate_token, hash_password, verify_password
+from .observability import (
+    build_health_auth_block,
+    build_health_fleet_block,
+    build_metrics_auth_block,
+    build_metrics_fleet_block,
+)
 
 log = logging.getLogger(__name__)
 
@@ -853,6 +859,14 @@ async def health() -> JSONResponse:
             "last_poll_at": _CT_STATS["last_poll_at"],
             "findings_count": ct_findings,
         },
+        # Phase 6 Wave B3 — REQ-P1-P6-005 / DEC-HEALTH-002
+        # Minimal auth + fleet counters. Per DEC-OBSERVABILITY-P6-001:
+        # - auth block: mode, users_count, last_login_at only (no per-role detail)
+        # - fleet block: manifest_fetches_24h + last_manifest_fetch_at only
+        # Rich operational stats (per-role counts, token buckets, tag totals)
+        # are auth-gated in /metrics per DEC-HEALTH-002.
+        "auth": build_health_auth_block(_db, _settings),
+        "fleet": build_health_fleet_block(_db),
     })
 
 
@@ -983,6 +997,12 @@ async def metrics() -> JSONResponse:
         # DEC-HEALTH-002: all error counters, cursor fields, and lifetime totals
         # live here behind auth, NOT in the public /health endpoint.
         "cloudtrail": _build_cloudtrail_metrics_block(_db, _settings),
+        # Phase 6 Wave B3 — per-role auth stats + fleet operational stats.
+        # (REQ-P1-P6-005, DEC-OBSERVABILITY-P6-001, DEC-HEALTH-002)
+        # Richer than the public /health blocks: per-role user counts, token
+        # buckets, tag totals, deployed rule counts, and manifest endpoint list.
+        "auth": build_metrics_auth_block(_db, _settings),
+        "fleet": build_metrics_fleet_block(_db),
     })
 
 

--- a/agent/models.py
+++ b/agent/models.py
@@ -2721,6 +2721,226 @@ def count_audit_events(conn: sqlite3.Connection) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Phase 6 Wave B3 — observability CRUD helpers (REQ-P1-P6-005)
+#
+# These helpers power /health auth.*/fleet.* and /metrics auth/fleet sections.
+# All read from existing tables — no new tables (DEC-SCHEMA-002).
+# ---------------------------------------------------------------------------
+
+
+def get_max_user_last_login(conn: sqlite3.Connection) -> Optional[str]:
+    """Return the most recent last_login_at value across all users, or None.
+
+    Used by /health auth block to report the latest login timestamp without
+    exposing per-user details (DEC-HEALTH-002).
+
+    Returns None when no user has ever logged in (last_login_at IS NULL for
+    all rows, or the table is empty).
+    """
+    row = conn.execute(
+        "SELECT MAX(last_login_at) FROM users WHERE last_login_at IS NOT NULL"
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return row[0]
+
+
+def get_max_user_created_at(conn: sqlite3.Connection) -> Optional[str]:
+    """Return the most recent created_at value across all users, or None.
+
+    Used by /metrics auth block to report when the newest user was added.
+    """
+    row = conn.execute("SELECT MAX(created_at) FROM users").fetchone()
+    if row is None or row[0] is None:
+        return None
+    return row[0]
+
+
+def count_users_by_role(conn: sqlite3.Connection) -> dict:
+    """Return a dict mapping each role to its user count.
+
+    Only counts non-disabled users so disabled accounts do not inflate
+    operational role counters.  Returns a dict with 0-count entries for
+    roles that have no users (guaranteed keys: admin, operator, viewer).
+
+    Used by /metrics auth.users_by_role.
+    """
+    rows = conn.execute(
+        """
+        SELECT role, COUNT(*) AS cnt
+          FROM users
+         WHERE disabled = 0
+         GROUP BY role
+        """
+    ).fetchall()
+    counts: dict = {"admin": 0, "operator": 0, "viewer": 0}
+    for row in rows:
+        counts[row[0]] = row[1]
+    return counts
+
+
+def count_users_disabled(conn: sqlite3.Connection) -> int:
+    """Return the count of users with disabled=1.
+
+    Used by /metrics auth.users_disabled_count.
+    """
+    row = conn.execute("SELECT COUNT(*) FROM users WHERE disabled = 1").fetchone()
+    return row[0] if row else 0
+
+
+def count_tokens_by_status(conn: sqlite3.Connection) -> dict:
+    """Return token counts bucketed into active, revoked, and expired.
+
+    Definitions:
+      active  -- revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now)
+      revoked -- revoked_at IS NOT NULL
+      expired -- revoked_at IS NULL AND expires_at IS NOT NULL AND expires_at <= now
+
+    Used by /metrics auth.tokens_*.
+
+    Returns dict with keys: active, revoked, expired.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    row_active = conn.execute(
+        """
+        SELECT COUNT(*) FROM user_tokens
+         WHERE revoked_at IS NULL
+           AND (expires_at IS NULL OR expires_at > ?)
+        """,
+        (now_iso,),
+    ).fetchone()
+
+    row_revoked = conn.execute(
+        "SELECT COUNT(*) FROM user_tokens WHERE revoked_at IS NOT NULL"
+    ).fetchone()
+
+    row_expired = conn.execute(
+        """
+        SELECT COUNT(*) FROM user_tokens
+         WHERE revoked_at IS NULL
+           AND expires_at IS NOT NULL
+           AND expires_at <= ?
+        """,
+        (now_iso,),
+    ).fetchone()
+
+    return {
+        "active": row_active[0] if row_active else 0,
+        "revoked": row_revoked[0] if row_revoked else 0,
+        "expired": row_expired[0] if row_expired else 0,
+    }
+
+
+def count_audit_events_by_path_prefix(
+    conn: sqlite3.Connection,
+    prefix: str,
+    since_ts: str,
+) -> int:
+    """Return the number of audit_log rows whose path starts with *prefix* since *since_ts*.
+
+    Used by /health fleet.manifest_fetches_24h and /metrics fleet.manifest_fetches_24h.
+
+    Args:
+        conn:     Open SQLite connection.
+        prefix:   Path prefix to match (e.g. '/fleet/manifest/').
+        since_ts: ISO-8601 timestamp lower bound (inclusive, string comparison).
+
+    Returns:
+        Integer count, 0 if no matching rows.
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) FROM audit_log WHERE path LIKE ? AND ts >= ?",
+        (prefix + "%", since_ts),
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def get_latest_audit_event_by_path_prefix(
+    conn: sqlite3.Connection,
+    prefix: str,
+) -> Optional[sqlite3.Row]:
+    """Return the most recent audit_log row whose path starts with *prefix*, or None.
+
+    Used by /health fleet.last_manifest_fetch_at and /metrics fleet.last_manifest_fetch_at.
+
+    Args:
+        conn:   Open SQLite connection.
+        prefix: Path prefix to match (e.g. '/fleet/manifest/').
+
+    Returns:
+        sqlite3.Row for the highest-id matching row, or None if no rows match.
+    """
+    return conn.execute(
+        """
+        SELECT * FROM audit_log
+         WHERE path LIKE ?
+         ORDER BY id DESC
+         LIMIT 1
+        """,
+        (prefix + "%",),
+    ).fetchone()
+
+
+def count_rules_tagged(conn: sqlite3.Connection) -> int:
+    """Return the number of distinct rule_ids that have at least one tag.
+
+    Used by /metrics fleet.rules_tagged_total.
+    """
+    row = conn.execute(
+        "SELECT COUNT(DISTINCT rule_id) FROM rule_tags"
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def count_distinct_tags(conn: sqlite3.Connection) -> int:
+    """Return the number of distinct tag values in rule_tags.
+
+    Used by /metrics fleet.tags_total.
+    """
+    row = conn.execute("SELECT COUNT(DISTINCT tag) FROM rule_tags").fetchone()
+    return row[0] if row else 0
+
+
+def count_rules_deployed(conn: sqlite3.Connection) -> int:
+    """Return the number of rules with deployed=1.
+
+    Used by /metrics fleet.rules_deployed_count.
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) FROM rules WHERE deployed = 1"
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def list_distinct_manifest_paths_24h(
+    conn: sqlite3.Connection,
+    since_ts: str,
+) -> list:
+    """Return distinct path values from audit_log matching /fleet/manifest/* in the last 24h.
+
+    Used by /metrics fleet.manifest_endpoints_seen.
+
+    Args:
+        conn:     Open SQLite connection.
+        since_ts: ISO-8601 timestamp lower bound (inclusive).
+
+    Returns:
+        Sorted list of distinct path strings (e.g. ['/fleet/manifest/edr-prod', ...]).
+    """
+    rows = conn.execute(
+        """
+        SELECT DISTINCT path FROM audit_log
+         WHERE path LIKE '/fleet/manifest/%'
+           AND ts >= ?
+         ORDER BY path ASC
+        """,
+        (since_ts,),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+# ---------------------------------------------------------------------------
 # Phase 6 Wave A4 — rule_tags CRUD helpers (REQ-P0-P6-001, DEC-FLEET-P6-002)
 # ---------------------------------------------------------------------------
 

--- a/agent/observability.py
+++ b/agent/observability.py
@@ -1,0 +1,258 @@
+"""
+Phase 6 Wave B3 — /health and /metrics observability block builders.
+
+Pulls auth.* and fleet.* block construction out of agent/main.py to keep
+the route handlers lean (same structural pattern as _build_cloudtrail_metrics_block
+introduced in Phase 5 Wave A3).
+
+Four public functions:
+  build_health_auth_block    — minimal auth summary for the public /health probe
+  build_health_fleet_block   — minimal fleet summary for the public /health probe
+  build_metrics_auth_block   — rich per-role auth stats for the auth-gated /metrics
+  build_metrics_fleet_block  — rich fleet operational stats for /metrics
+
+DEC-HEALTH-002 invariant is enforced structurally: the health_* functions only
+return counters and one timestamp; per-user/per-token details are metrics_* only.
+
+@decision DEC-OBSERVABILITY-P6-001
+@title Audit-log as source-of-truth for fleet counters; observability blocks in own module
+@status accepted
+@rationale
+  Two design choices captured here:
+
+  1. Fleet counter source — The audit_log table (written by AuditMiddleware on
+     every request) is the authoritative counter for manifest fetches.  The
+     alternative (in-memory FLEET_STATS dict incremented by the manifest route)
+     was rejected because: (a) it resets on restart, losing history; (b) it
+     adds mutable shared state; (c) it duplicates the source-of-truth role
+     already filled by audit_log.  Querying audit_log for path LIKE
+     '/fleet/manifest/%' is a simple indexed scan on a small table — acceptable
+     O(N) cost for a low-traffic operational endpoint.
+
+  2. Module split — Block builders are extracted into agent/observability.py
+     rather than inlined in agent/main.py.  agent/main.py already imports from
+     ~12 modules; adding 4 more multi-line helper functions would push it past
+     ~2000 lines.  The module split mirrors _build_cloudtrail_metrics_block's
+     predecessor pattern and allows unit-testing the block builders independently
+     of the FastAPI request/response cycle if needed.
+
+  DEC-HEALTH-002 preserved: /health receives only mode, users_count,
+  last_login_at (auth) and manifest_fetches_24h, last_manifest_fetch_at (fleet).
+  All richer stats (per-role counts, token buckets, tag totals, deployed counts)
+  remain in the auth-gated /metrics.
+"""
+
+import sqlite3
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+from .models import (
+    count_audit_events_by_path_prefix,
+    count_distinct_tags,
+    count_rules_deployed,
+    count_rules_tagged,
+    count_tokens_by_status,
+    count_users,
+    count_users_by_role,
+    count_users_disabled,
+    get_latest_audit_event_by_path_prefix,
+    get_max_user_created_at,
+    get_max_user_last_login,
+    list_distinct_manifest_paths_24h,
+)
+from .canary import sanitize_alert_field as _sanitize
+
+_FLEET_MANIFEST_PREFIX = "/fleet/manifest/"
+
+
+def _since_24h_iso() -> str:
+    """Return ISO-8601 timestamp for 24 hours ago (UTC)."""
+    return (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# /health block builders (public, no auth required)
+# ---------------------------------------------------------------------------
+
+
+def build_health_auth_block(conn: Optional[sqlite3.Connection], settings) -> dict:
+    """Build the minimal auth summary dict for the public /health endpoint.
+
+    Fields (DEC-HEALTH-002 — minimal, no recon value):
+      mode         -- 'single' or 'multi', from settings.shaferhund_auth_mode
+      users_count  -- total rows in users table (0 in single mode)
+      last_login_at -- max last_login_at across all users, or null
+
+    Args:
+        conn:     Open sqlite3.Connection or None (returns zero-state if None).
+        settings: Settings-like object or None.
+
+    Returns:
+        dict with keys: mode, users_count, last_login_at
+    """
+    auth_mode = (
+        getattr(settings, "shaferhund_auth_mode", "single")
+        if settings is not None
+        else "single"
+    )
+    if conn is None:
+        return {"mode": auth_mode, "users_count": 0, "last_login_at": None}
+
+    users_count = count_users(conn)
+    last_login_at = get_max_user_last_login(conn)
+
+    return {
+        "mode": auth_mode,
+        "users_count": users_count,
+        "last_login_at": last_login_at,
+    }
+
+
+def build_health_fleet_block(conn: Optional[sqlite3.Connection]) -> dict:
+    """Build the minimal fleet summary dict for the public /health endpoint.
+
+    Fields (DEC-HEALTH-002 — counters and one timestamp only):
+      manifest_fetches_24h    -- audit_log rows for /fleet/manifest/* in last 24h
+      last_manifest_fetch_at  -- ts of most recent such row, or null
+
+    Source of truth is audit_log (DEC-OBSERVABILITY-P6-001).
+
+    Args:
+        conn: Open sqlite3.Connection or None (returns zero-state if None).
+
+    Returns:
+        dict with keys: manifest_fetches_24h, last_manifest_fetch_at
+    """
+    if conn is None:
+        return {"manifest_fetches_24h": 0, "last_manifest_fetch_at": None}
+
+    since = _since_24h_iso()
+    fetches_24h = count_audit_events_by_path_prefix(conn, _FLEET_MANIFEST_PREFIX, since)
+    latest_row = get_latest_audit_event_by_path_prefix(conn, _FLEET_MANIFEST_PREFIX)
+    last_fetch_at = latest_row["ts"] if latest_row is not None else None
+
+    return {
+        "manifest_fetches_24h": fetches_24h,
+        "last_manifest_fetch_at": last_fetch_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# /metrics block builders (auth-gated, richer operational stats)
+# ---------------------------------------------------------------------------
+
+
+def build_metrics_auth_block(
+    conn: Optional[sqlite3.Connection], settings
+) -> dict:
+    """Build the rich auth stats dict for the auth-gated /metrics endpoint.
+
+    Fields:
+      mode                -- 'single' or 'multi'
+      users_total         -- COUNT(*) from users
+      users_by_role       -- {admin: N, operator: N, viewer: N} (non-disabled only)
+      users_disabled_count -- COUNT(*) WHERE disabled=1
+      tokens_active_count  -- tokens not revoked and not expired
+      tokens_revoked_count -- tokens with revoked_at IS NOT NULL
+      tokens_expired_count -- tokens past expires_at (not revoked)
+      last_login_at        -- max last_login_at across all users, or null
+      last_user_created_at -- max created_at across all users, or null
+
+    Args:
+        conn:     Open sqlite3.Connection or None (returns zero-state if None).
+        settings: Settings-like object or None.
+
+    Returns:
+        dict with 9 keys.
+    """
+    auth_mode = (
+        getattr(settings, "shaferhund_auth_mode", "single")
+        if settings is not None
+        else "single"
+    )
+    if conn is None:
+        return {
+            "mode": auth_mode,
+            "users_total": 0,
+            "users_by_role": {"admin": 0, "operator": 0, "viewer": 0},
+            "users_disabled_count": 0,
+            "tokens_active_count": 0,
+            "tokens_revoked_count": 0,
+            "tokens_expired_count": 0,
+            "last_login_at": None,
+            "last_user_created_at": None,
+        }
+
+    users_total = count_users(conn)
+    users_by_role = count_users_by_role(conn)
+    users_disabled = count_users_disabled(conn)
+    token_buckets = count_tokens_by_status(conn)
+    last_login_at = get_max_user_last_login(conn)
+    last_created_at = get_max_user_created_at(conn)
+
+    return {
+        "mode": auth_mode,
+        "users_total": users_total,
+        "users_by_role": users_by_role,
+        "users_disabled_count": users_disabled,
+        "tokens_active_count": token_buckets["active"],
+        "tokens_revoked_count": token_buckets["revoked"],
+        "tokens_expired_count": token_buckets["expired"],
+        "last_login_at": last_login_at,
+        "last_user_created_at": last_created_at,
+    }
+
+
+def build_metrics_fleet_block(conn: Optional[sqlite3.Connection]) -> dict:
+    """Build the rich fleet stats dict for the auth-gated /metrics endpoint.
+
+    Fields:
+      manifest_fetches_24h    -- audit_log rows for /fleet/manifest/* in last 24h
+      last_manifest_fetch_at  -- ts of most recent such row, or null
+      rules_tagged_total       -- distinct rule_ids in rule_tags
+      tags_total               -- distinct tag values in rule_tags
+      rules_deployed_count     -- COUNT(*) WHERE deployed=1 in rules
+      manifest_endpoints_seen  -- sorted list of distinct paths from audit_log (24h)
+
+    manifest_endpoints_seen path values are passed through sanitize_alert_field
+    before inclusion (operator-influenced strings, REQ-MUST-PRESERVE-003).
+
+    Source of truth is audit_log for fleet counters (DEC-OBSERVABILITY-P6-001).
+
+    Args:
+        conn: Open sqlite3.Connection or None (returns zero-state if None).
+
+    Returns:
+        dict with 6 keys.
+    """
+    if conn is None:
+        return {
+            "manifest_fetches_24h": 0,
+            "last_manifest_fetch_at": None,
+            "rules_tagged_total": 0,
+            "tags_total": 0,
+            "rules_deployed_count": 0,
+            "manifest_endpoints_seen": [],
+        }
+
+    since = _since_24h_iso()
+    fetches_24h = count_audit_events_by_path_prefix(conn, _FLEET_MANIFEST_PREFIX, since)
+    latest_row = get_latest_audit_event_by_path_prefix(conn, _FLEET_MANIFEST_PREFIX)
+    last_fetch_at = latest_row["ts"] if latest_row is not None else None
+
+    rules_tagged = count_rules_tagged(conn)
+    tags_total = count_distinct_tags(conn)
+    rules_deployed = count_rules_deployed(conn)
+
+    raw_paths = list_distinct_manifest_paths_24h(conn, since)
+    # sanitize_alert_field on operator-influenced path strings (CSO)
+    safe_paths = [_sanitize(p) for p in raw_paths]
+
+    return {
+        "manifest_fetches_24h": fetches_24h,
+        "last_manifest_fetch_at": last_fetch_at,
+        "rules_tagged_total": rules_tagged,
+        "tags_total": tags_total,
+        "rules_deployed_count": rules_deployed,
+        "manifest_endpoints_seen": safe_paths,
+    }

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -150,7 +150,7 @@ def _make_config(max_calls: int = 5, wall_timeout: float = 10.0) -> SimpleNamesp
 
 
 def test_health_returns_only_liveness_fields(tmp_path):
-    """GET /health → exactly {status, poller_healthy, threat_intel, canary, posture, recommendations, cloudtrail}.
+    """GET /health → exactly {status, poller_healthy, threat_intel, canary, posture, recommendations, cloudtrail, auth, fleet}.
 
     Phase 3 (REQ-P0-P3-005) added threat_intel.record_count to /health.
     Phase 3 (REQ-P0-P3-004) added canary.trigger_count_24h to /health.
@@ -159,6 +159,7 @@ def test_health_returns_only_liveness_fields(tmp_path):
     Phase 4 (REQ-P0-P4-005) adds posture.slo_breach_open to /health.
     Phase 4 Wave B (REQ-P0-P4-001) adds recommendations.pending_count to /health.
     Phase 5 Wave A3 (REQ-P0-P5-006) adds cloudtrail block to /health.
+    Phase 6 Wave B3 (REQ-P1-P6-005) adds auth + fleet blocks to /health (9 keys total).
     All fields are minimal summary values that do not expose operational detail,
     consistent with DEC-HEALTH-002's "public liveness probe" intent.
     """
@@ -171,9 +172,9 @@ def test_health_returns_only_liveness_fields(tmp_path):
     data = resp.json()
     assert set(data.keys()) == {
         "status", "poller_healthy", "threat_intel", "canary", "posture",
-        "recommendations", "cloudtrail",
+        "recommendations", "cloudtrail", "auth", "fleet",
     }, (
-        f"Expected exactly 7 keys including 'cloudtrail' (Phase 5 Wave A3), "
+        f"Expected exactly 9 keys including 'auth' and 'fleet' (Phase 6 Wave B3), "
         f"got keys: {set(data.keys())}"
     )
     assert data["status"] == "ok"

--- a/tests/test_observability_health.py
+++ b/tests/test_observability_health.py
@@ -1,0 +1,236 @@
+"""
+/health auth.* and fleet.* block tests — Phase 6 Wave B3, REQ-P1-P6-005.
+
+Verifies:
+  1. auth block present in single mode (zero-state)
+  2. auth block present in multi mode with no users
+  3. auth block reflects seeded users and last_login_at
+  4. fleet block present with no activity (zeros + null)
+  5. fleet block reflects audit_log after a real manifest GET
+  6. top-level /health key set is exactly the 9-key set after Phase 6 Wave B3
+
+Approach: patch agent.main singletons (_db, _settings) directly — same
+pattern as test_health.py.  The fleet manifest test uses TestClient to
+exercise the real manifest route so audit_log is written by AuditMiddleware,
+verifying the end-to-end counter path.
+
+# @mock-exempt: No mocks of internal modules. _db and _settings are module-level
+# singletons (not function arguments) — patching them at the module level is the
+# only way to inject test state without running the full lifespan.  AuditMiddleware,
+# models, and observability are exercised against their real implementations.
+"""
+
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import agent.main as main_module
+import agent.sources.cloudtrail as ct_module
+from agent.auth import generate_token, hash_password
+from agent.models import (
+    init_db,
+    insert_rule,
+    insert_user,
+    insert_user_token,
+    tag_rule,
+    update_user_last_login,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EXPECTED_HEALTH_KEYS = {
+    "status",
+    "poller_healthy",
+    "threat_intel",
+    "canary",
+    "posture",
+    "recommendations",
+    "cloudtrail",
+    "auth",
+    "fleet",
+}
+
+
+def _make_settings(auth_mode: str = "single") -> SimpleNamespace:
+    return SimpleNamespace(
+        shaferhund_token="",
+        shaferhund_auth_mode=auth_mode,
+        db_path=":memory:",
+        alerts_file="/dev/null",
+        suricata_eve_file="/dev/null",
+        triage_hourly_budget=20,
+        AUTO_DEPLOY_ENABLED=False,
+        sigmac_available=False,
+        sigmac_version=None,
+        cloudtrail_enabled=False,
+        cloudtrail_s3_bucket="",
+        cloudtrail_s3_prefix="",
+        # audit key — required by AuditMiddleware
+        shaferhund_audit_key="aa" * 32,
+    )
+
+
+def _patch_singletons(conn, settings):
+    """Patch main module singletons and reset ancillary state."""
+    import hashlib
+    main_module._db = conn
+    main_module._settings = settings
+    main_module._triage_queue = None
+    main_module._poller_healthy = False
+    main_module._last_poll_at = None
+    main_module._audit_hmac_key = bytes.fromhex(settings.shaferhund_audit_key)
+    # Reset CloudTrail stats to avoid cross-test pollution
+    ct_module.CLOUDTRAIL_STATS["last_poll_at"] = None
+    ct_module.CLOUDTRAIL_STATS["last_poll_status"] = None
+    ct_module.CLOUDTRAIL_STATS["events_ingested_total"] = 0
+    ct_module.CLOUDTRAIL_STATS["s3_list_errors_total"] = 0
+    ct_module.CLOUDTRAIL_STATS["parse_errors_total"] = 0
+    ct_module.CLOUDTRAIL_STATS["objects_processed_total"] = 0
+
+
+def _client(conn, settings) -> TestClient:
+    _patch_singletons(conn, settings)
+    return TestClient(main_module.app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests — auth block
+# ---------------------------------------------------------------------------
+
+
+def test_health_includes_auth_block_single_mode():
+    """single mode + empty users table → auth = {mode:'single', users_count:0, last_login_at:null}."""
+    conn = init_db(":memory:")
+    settings = _make_settings(auth_mode="single")
+    c = _client(conn, settings)
+
+    resp = c.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    auth = data["auth"]
+    assert auth["mode"] == "single"
+    assert auth["users_count"] == 0
+    assert auth["last_login_at"] is None
+
+
+def test_health_includes_auth_block_multi_mode_no_users():
+    """multi mode + empty users table → auth = {mode:'multi', users_count:0, last_login_at:null}."""
+    conn = init_db(":memory:")
+    settings = _make_settings(auth_mode="multi")
+    c = _client(conn, settings)
+
+    resp = c.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    auth = data["auth"]
+    assert auth["mode"] == "multi"
+    assert auth["users_count"] == 0
+    assert auth["last_login_at"] is None
+
+
+def test_health_includes_auth_block_multi_mode_with_users_and_login():
+    """2 users, one has logged in → users_count=2, last_login_at reflects that ts."""
+    conn = init_db(":memory:")
+    settings = _make_settings(auth_mode="multi")
+
+    ph = hash_password("pw")
+    uid1 = insert_user(conn, "alice", ph, "admin")
+    uid2 = insert_user(conn, "bob", ph, "viewer")
+
+    login_ts = "2026-04-24T10:00:00+00:00"
+    update_user_last_login(conn, uid1, login_ts)
+    # uid2 has never logged in (last_login_at stays NULL)
+
+    c = _client(conn, settings)
+    resp = c.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    auth = data["auth"]
+    assert auth["mode"] == "multi"
+    assert auth["users_count"] == 2
+    assert auth["last_login_at"] == login_ts
+
+
+# ---------------------------------------------------------------------------
+# Tests — fleet block
+# ---------------------------------------------------------------------------
+
+
+def test_health_includes_fleet_block_no_activity():
+    """No manifest fetches → fleet = {manifest_fetches_24h:0, last_manifest_fetch_at:null}."""
+    conn = init_db(":memory:")
+    settings = _make_settings(auth_mode="single")
+    c = _client(conn, settings)
+
+    resp = c.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    fleet = data["fleet"]
+    assert fleet["manifest_fetches_24h"] == 0
+    assert fleet["last_manifest_fetch_at"] is None
+
+
+def test_health_includes_fleet_block_after_manifest_fetch():
+    """After a real GET /fleet/manifest/<tag>, manifest_fetches_24h == 1 and last_manifest_fetch_at is set."""
+    conn = init_db(":memory:")
+    settings = _make_settings(auth_mode="multi")
+    # Need a valid user + token to hit the auth-gated manifest route
+    ph = hash_password("pw")
+    uid = insert_user(conn, "admin", ph, "admin")
+    raw, h = generate_token()
+    insert_user_token(conn, uid, h, "admin-tok")
+
+    # Seed a deployed rule with the tag so the manifest is non-empty.
+    # cluster_id=None avoids FK constraint (NULL is valid for nullable FKs in SQLite).
+    insert_rule(conn, rule_id="rule-obs-1", cluster_id=None,
+                rule_type="yara", rule_content="rule r {}", syntax_valid=True)
+    conn.execute("UPDATE rules SET deployed = 1 WHERE id = ?", ("rule-obs-1",))
+    conn.commit()
+    tag_rule(conn, "rule-obs-1", "edr-test")
+
+    c = _client(conn, settings)
+
+    # Hit the manifest endpoint — AuditMiddleware will write an audit_log row
+    resp_manifest = c.get(
+        "/fleet/manifest/edr-test",
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert resp_manifest.status_code == 200
+
+    resp = c.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    fleet = data["fleet"]
+    assert fleet["manifest_fetches_24h"] == 1
+    assert fleet["last_manifest_fetch_at"] is not None
+    # Timestamp should be a recent ISO string
+    assert "2026" in fleet["last_manifest_fetch_at"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — total key set
+# ---------------------------------------------------------------------------
+
+
+def test_health_total_keys():
+    """Top-level /health keys are exactly the 9-key set after Phase 6 Wave B3."""
+    conn = init_db(":memory:")
+    settings = _make_settings(auth_mode="single")
+    c = _client(conn, settings)
+
+    resp = c.get("/health")
+    assert resp.status_code == 200
+    assert set(resp.json().keys()) == _EXPECTED_HEALTH_KEYS, (
+        f"Expected {_EXPECTED_HEALTH_KEYS}, got {set(resp.json().keys())}"
+    )

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,302 @@
+"""
+/metrics auth + fleet section tests — Phase 6 Wave B3, REQ-P1-P6-005.
+
+Verifies:
+  1. /metrics without auth returns 401 (regression guard)
+  2. /metrics with auth includes the auth section with all 9 keys
+  3. users_by_role aggregates correctly (1 admin + 2 operators + 3 viewers)
+  4. tokens_by_status buckets correctly (2 active + 1 revoked + 1 expired)
+  5. /metrics with auth includes the fleet section with all 6 keys
+  6. rules_deployed_count counts only deployed=1 rules
+  7. manifest_endpoints_seen reflects paths fetched in the last 24h
+
+Approach: multi-auth mode with real in-memory SQLite.  _settings and _db
+are patched at the module level (same pattern as test_route_role_tags.py).
+AuditMiddleware writes real audit_log rows when TestClient exercises routes.
+
+# @mock-exempt: No mocks of internal modules. The audit_log source-of-truth
+# for fleet counters is exercised end-to-end by hitting /fleet/manifest/* via
+# TestClient — the same path a real fleet agent would use (DEC-OBSERVABILITY-P6-001).
+"""
+
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import agent.main as main_module
+import agent.sources.cloudtrail as ct_module
+from agent.auth import generate_token, hash_password
+from agent.config import Settings
+from agent.models import (
+    init_db,
+    insert_rule,
+    insert_user,
+    insert_user_token,
+    revoke_user_token,
+    set_user_disabled,
+    tag_rule,
+    update_user_last_login,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_AUTH_SECTION_KEYS = {
+    "mode",
+    "users_total",
+    "users_by_role",
+    "users_disabled_count",
+    "tokens_active_count",
+    "tokens_revoked_count",
+    "tokens_expired_count",
+    "last_login_at",
+    "last_user_created_at",
+}
+
+_FLEET_SECTION_KEYS = {
+    "manifest_fetches_24h",
+    "last_manifest_fetch_at",
+    "rules_tagged_total",
+    "tags_total",
+    "rules_deployed_count",
+    "manifest_endpoints_seen",
+}
+
+
+def _make_multi_settings() -> Settings:
+    return Settings(
+        anthropic_api_key="test-key",
+        shaferhund_token="",
+        shaferhund_auth_mode="multi",
+        shaferhund_audit_key="bb" * 32,
+    )
+
+
+def _patch_singletons(conn, settings):
+    main_module._db = conn
+    main_module._settings = settings
+    main_module._triage_queue = None
+    main_module._poller_healthy = False
+    main_module._last_poll_at = None
+    main_module._audit_hmac_key = bytes.fromhex(settings.shaferhund_audit_key)
+    ct_module.CLOUDTRAIL_STATS["last_poll_at"] = None
+    ct_module.CLOUDTRAIL_STATS["last_poll_status"] = None
+    ct_module.CLOUDTRAIL_STATS["events_ingested_total"] = 0
+    ct_module.CLOUDTRAIL_STATS["s3_list_errors_total"] = 0
+    ct_module.CLOUDTRAIL_STATS["parse_errors_total"] = 0
+    ct_module.CLOUDTRAIL_STATS["objects_processed_total"] = 0
+
+
+def _setup(conn=None):
+    """Return (conn, settings, TestClient) with a fresh admin user + token."""
+    if conn is None:
+        conn = init_db(":memory:")
+    settings = _make_multi_settings()
+    _patch_singletons(conn, settings)
+
+    ph = hash_password("pw")
+    uid = insert_user(conn, "admin", ph, "admin")
+    raw, h = generate_token()
+    insert_user_token(conn, uid, h, "admin-tok")
+
+    client = TestClient(main_module.app, raise_server_exceptions=True)
+    return conn, raw, client
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Tests — basic auth gate
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_no_auth_returns_401():
+    """GET /metrics without a token returns 401 (regression: auth gate must stay)."""
+    conn = init_db(":memory:")
+    settings = _make_multi_settings()
+    _patch_singletons(conn, settings)
+    c = TestClient(main_module.app, raise_server_exceptions=True)
+    assert c.get("/metrics").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Tests — auth section
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_with_auth_includes_auth_section():
+    """auth section present and has all 9 expected keys."""
+    conn, token, c = _setup()
+    resp = c.get("/metrics", headers=_auth(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "auth" in data, "auth section missing from /metrics"
+    assert set(data["auth"].keys()) == _AUTH_SECTION_KEYS, (
+        f"auth section keys mismatch: {set(data['auth'].keys())}"
+    )
+
+
+def test_metrics_users_by_role_counts_correct():
+    """1 admin + 2 operators + 3 viewers → users_by_role correct."""
+    conn = init_db(":memory:")
+    ph = hash_password("pw")
+
+    # Seed roles: 1 admin (also the requesting user), 2 operators, 3 viewers
+    admin_uid = insert_user(conn, "admin", ph, "admin")
+    raw, h = generate_token()
+    insert_user_token(conn, admin_uid, h, "admin-tok")
+
+    for i in range(2):
+        insert_user(conn, f"op{i}", ph, "operator")
+    for i in range(3):
+        insert_user(conn, f"viewer{i}", ph, "viewer")
+
+    settings = _make_multi_settings()
+    _patch_singletons(conn, settings)
+    c = TestClient(main_module.app, raise_server_exceptions=True)
+
+    resp = c.get("/metrics", headers=_auth(raw))
+    assert resp.status_code == 200
+    by_role = resp.json()["auth"]["users_by_role"]
+    assert by_role["admin"] == 1, f"expected 1 admin, got {by_role['admin']}"
+    assert by_role["operator"] == 2, f"expected 2 operators, got {by_role['operator']}"
+    assert by_role["viewer"] == 3, f"expected 3 viewers, got {by_role['viewer']}"
+
+
+def test_metrics_tokens_by_status():
+    """2 active + 1 revoked + 1 expired → correct token bucket counts."""
+    conn = init_db(":memory:")
+    ph = hash_password("pw")
+    uid = insert_user(conn, "admin", ph, "admin")
+
+    # Token 1 — admin auth token (active, no expiry)
+    raw_admin, h_admin = generate_token()
+    insert_user_token(conn, uid, h_admin, "admin-auth")
+
+    # Token 2 — active with future expiry
+    future_ts = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+    raw2, h2 = generate_token()
+    insert_user_token(conn, uid, h2, "active-expiry", expires_at=future_ts)
+
+    # Token 3 — revoked
+    raw3, h3 = generate_token()
+    tok3_id = insert_user_token(conn, uid, h3, "revoked-tok")
+    revoke_user_token(conn, tok3_id, datetime.now(timezone.utc).isoformat())
+
+    # Token 4 — expired (past expires_at, not revoked)
+    past_ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    raw4, h4 = generate_token()
+    insert_user_token(conn, uid, h4, "expired-tok", expires_at=past_ts)
+
+    settings = _make_multi_settings()
+    _patch_singletons(conn, settings)
+    c = TestClient(main_module.app, raise_server_exceptions=True)
+
+    resp = c.get("/metrics", headers=_auth(raw_admin))
+    assert resp.status_code == 200
+    auth_section = resp.json()["auth"]
+
+    assert auth_section["tokens_active_count"] == 2, (
+        f"expected 2 active, got {auth_section['tokens_active_count']}"
+    )
+    assert auth_section["tokens_revoked_count"] == 1, (
+        f"expected 1 revoked, got {auth_section['tokens_revoked_count']}"
+    )
+    assert auth_section["tokens_expired_count"] == 1, (
+        f"expected 1 expired, got {auth_section['tokens_expired_count']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — fleet section
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_with_auth_includes_fleet_section():
+    """fleet section present and has all 6 expected keys."""
+    conn, token, c = _setup()
+    resp = c.get("/metrics", headers=_auth(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "fleet" in data, "fleet section missing from /metrics"
+    assert set(data["fleet"].keys()) == _FLEET_SECTION_KEYS, (
+        f"fleet section keys mismatch: {set(data['fleet'].keys())}"
+    )
+
+
+def test_metrics_rules_deployed_count():
+    """3 deployed + 2 undeployed rules → rules_deployed_count == 3."""
+    conn = init_db(":memory:")
+    ph = hash_password("pw")
+    uid = insert_user(conn, "admin", ph, "admin")
+    raw, h = generate_token()
+    insert_user_token(conn, uid, h, "admin-tok")
+
+    # Seed 3 deployed and 2 undeployed rules.
+    # cluster_id=None avoids FK constraint (NULL is valid for nullable FKs in SQLite).
+    for i in range(3):
+        insert_rule(conn, rule_id=f"rule-dep-{i}", cluster_id=None,
+                    rule_type="yara", rule_content=f"rule r{i} {{}}", syntax_valid=True)
+        conn.execute("UPDATE rules SET deployed = 1 WHERE id = ?", (f"rule-dep-{i}",))
+    for i in range(2):
+        insert_rule(conn, rule_id=f"rule-undep-{i}", cluster_id=None,
+                    rule_type="yara", rule_content=f"rule u{i} {{}}", syntax_valid=True)
+        # deployed stays 0 (default)
+    conn.commit()
+
+    settings = _make_multi_settings()
+    _patch_singletons(conn, settings)
+    c = TestClient(main_module.app, raise_server_exceptions=True)
+
+    resp = c.get("/metrics", headers=_auth(raw))
+    assert resp.status_code == 200
+    fleet = resp.json()["fleet"]
+    assert fleet["rules_deployed_count"] == 3, (
+        f"expected 3 deployed, got {fleet['rules_deployed_count']}"
+    )
+
+
+def test_metrics_manifest_endpoints_seen():
+    """Fetching /fleet/manifest/x and /fleet/manifest/y → both appear in manifest_endpoints_seen."""
+    conn = init_db(":memory:")
+    ph = hash_password("pw")
+    uid = insert_user(conn, "admin", ph, "admin")
+    raw, h = generate_token()
+    insert_user_token(conn, uid, h, "admin-tok")
+
+    # Seed deployed rules with two different tags.
+    # cluster_id=None avoids FK constraint (NULL is valid for nullable FKs in SQLite).
+    for tag in ("edr-prod", "ids-stage"):
+        rule_id = f"rule-{tag}"
+        insert_rule(conn, rule_id=rule_id, cluster_id=None,
+                    rule_type="yara",
+                    rule_content=f"rule r_{tag.replace('-', '_')} {{}}",
+                    syntax_valid=True)
+        conn.execute("UPDATE rules SET deployed = 1 WHERE id = ?", (rule_id,))
+        conn.commit()
+        tag_rule(conn, rule_id, tag)
+
+    settings = _make_multi_settings()
+    _patch_singletons(conn, settings)
+    c = TestClient(main_module.app, raise_server_exceptions=True)
+
+    # Fetch both manifest endpoints — AuditMiddleware writes audit_log rows
+    for tag in ("edr-prod", "ids-stage"):
+        resp_m = c.get(
+            f"/fleet/manifest/{tag}",
+            headers=_auth(raw),
+        )
+        assert resp_m.status_code == 200, f"manifest fetch for {tag} failed: {resp_m.status_code}"
+
+    resp = c.get("/metrics", headers=_auth(raw))
+    assert resp.status_code == 200
+    seen = resp.json()["fleet"]["manifest_endpoints_seen"]
+    assert "/fleet/manifest/edr-prod" in seen, f"edr-prod missing from seen: {seen}"
+    assert "/fleet/manifest/ids-stage" in seen, f"ids-stage missing from seen: {seen}"


### PR DESCRIPTION
## Scope

Phase 6 Wave B3 — observability extensions only. No new features, no new tables. New `agent/observability.py` (4 block-builder functions) reads existing tables (`users`, `user_tokens`, `audit_log`, `rule_tags`, `rules`) for counter aggregation.

## What changed

- `/health` extended with 2 new top-level keys:
  - `auth` — 3 sub-keys: `mode`, `users_count`, `last_login_at`
  - `fleet` — 2 sub-keys: `manifest_fetches_24h`, `last_manifest_fetch_at`
- `/metrics` extended with auth (8 keys) + fleet (6 keys) sections
- DEC-OBSERVABILITY-P6-001 invariant: `/health` stays public + minimal; operational stats live in `/metrics`

## DEC-HEALTH-002 split preserved

`/health` exposes 3 keys auth + 2 keys fleet (public, minimal). `/metrics` exposes 8 + 6 keys (auth-gated, operational). Verified: no `users_by_role`, `tokens_active_count`, `manifest_endpoints_seen` leak into `/health`.

## audit.py one-line deviation (option-a: audit-log-as-source-of-truth)

Single addition to `_AUDITED_GET_PREFIXES` frozenset: `/fleet/manifest/`. Required so manifest GETs are recorded in `audit_log` — the source of truth for `manifest_fetches_24h`. No separate in-memory counter is maintained. Diff is bounded: one entry + comment update; no signature changes, no HMAC code edits. Wave A3 audit chain (42 tests) and Wave B2 fleet client (124 combined tests) pass unchanged.

## Documented behavior

`count_users_by_role` excludes disabled users by design (`WHERE disabled = 0`); `users_total` counts all users including disabled. Difference appears explicitly as `users_disabled_count`. Documented behavior, not a bug.

## Verification (AUTOVERIFY: CLEAN)

- 592 passed / 2 skipped / 0 failed (+13 new tests over Wave B2's 581)
- TOOLS still 9
- Audit-log-as-source-of-truth verified live: 0 → 3 fetches matches `SELECT COUNT(*) FROM audit_log WHERE path LIKE '/fleet/manifest/%'`
- Auth gate matrix on `/metrics`: 401 anon; 200 viewer/operator/admin
- Single mode: `/health.auth = {mode: 'single', users_count: 0, last_login_at: null}` (block always present)
- Tester report: `tmp/verification-issue-75.md` in worktree

## Acknowledged low-risk gaps

1. 24h window boundary for `manifest_fetches_24h` not tested with time-skewed events
2. `sanitize_alert_field` on `manifest_endpoints_seen` paths with special chars not exercised

Closes #75