### PR TITLE
chore(security): htmx XSS hardening + loopback bind + CVE pins + sigma-cli 3.x + honest probe + time-bomb fix

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -215,14 +215,36 @@ _last_poll_at: Optional[str] = None
 # Sigma-cli startup probe
 # ---------------------------------------------------------------------------
 
-def _probe_sigmac(settings: Settings) -> None:
-    """Probe for sigma-cli at startup and mutate settings fields in place.
+# Minimal Sigma rule used by the wazuh-backend probe.  Kept as a module
+# constant so test_main_probe.py can import and assert against it.
+_PROBE_SIGMA_YAML = (
+    "title: Probe\n"
+    "id: 00000000-0000-0000-0000-000000000001\n"
+    "status: experimental\n"
+    "logsource:\n"
+    "  category: process_creation\n"
+    "  product: linux\n"
+    "detection:\n"
+    "  selection:\n"
+    "    Image|endswith: '/probe'\n"
+    "  condition: selection\n"
+    "level: low\n"
+)
 
-    Runs ``sigma --version`` once. On success, sets sigmac_available=True
-    and sigmac_version to the version string. On any failure
-    (FileNotFoundError, non-zero exit, or TimeoutExpired), leaves
-    sigmac_available=False and logs a single WARNING. Does NOT raise —
-    graceful degradation is the point.
+
+def _probe_sigmac(settings: Settings) -> None:
+    """Probe for sigma-cli + wazuh backend at startup; mutate settings in place.
+
+    Two-step probe:
+      1. ``sigma --version`` must return rc=0 with non-empty stdout.
+      2. ``sigma convert -t wazuh`` (fed _PROBE_SIGMA_YAML on stdin) must
+         return rc=0 with non-empty stdout — proving the wazuh backend plugin
+         is registered and actually converts.
+
+    Only when BOTH succeed is ``sigmac_available`` set to True.  Any other
+    outcome (binary missing, version succeeds but backend missing, convert
+    times out, etc.) leaves ``sigmac_available=False`` and logs a single
+    WARNING.  Does NOT raise — graceful degradation is the point.
 
     @decision DEC-SIGMA-DEGRADE-001
     @title Startup probe flips settings.sigmac_available once; downstream reads the bool
@@ -233,31 +255,56 @@ def _probe_sigmac(settings: Settings) -> None:
                for no benefit. Defaults to False so a misconfigured container can
                never accidentally auto-deploy Sigma rules before the probe confirms
                sigma-cli is usable (fail-safe default).
+
+    @decision DEC-DEPS-001
+    @title Probe verifies wazuh backend, not just sigma binary
+    @status accepted
+    @rationale sigma-cli 3.x dropped the upstream ``wazuh`` plugin from its
+               registry while pysigma>=1.2 is required by the orchestrator's
+               parser.  ``sigma --version`` succeeds on 3.x but
+               ``sigma convert -t wazuh`` errors with rc=2 ("invalid value for
+               --target").  Probing only ``--version`` would set
+               sigmac_available=True against a runtime that errors on every
+               deploy.  The probe must verify the backend it will actually
+               use; honest startup state is non-negotiable.
     """
+    unavailable_msg = (
+        "sigma-cli not available; Sigma rules will generate but not auto-deploy"
+    )
     try:
-        result = subprocess.run(
+        version_result = subprocess.run(
             ["sigma", "--version"],
             capture_output=True,
             text=True,
             timeout=5,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            settings.sigmac_available = True
-            settings.sigmac_version = result.stdout.strip()
-            log.info("sigma-cli available: %s", settings.sigmac_version)
+        if version_result.returncode != 0 or not version_result.stdout.strip():
+            log.warning(unavailable_msg)
             return
-        # Non-zero exit — treat as unavailable
-        log.warning(
-            "sigma-cli not available; Sigma rules will generate but not auto-deploy"
+        version_str = version_result.stdout.strip()
+
+        backend_result = subprocess.run(
+            ["sigma", "convert", "-t", "wazuh"],
+            input=_PROBE_SIGMA_YAML,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
+        if backend_result.returncode != 0 or not backend_result.stdout.strip():
+            log.warning(
+                "sigma-cli %s present but wazuh backend missing or non-functional; "
+                "Sigma rules will generate but not auto-deploy",
+                version_str,
+            )
+            return
+
+        settings.sigmac_available = True
+        settings.sigmac_version = version_str
+        log.info("sigma-cli available with wazuh backend: %s", version_str)
     except FileNotFoundError:
-        log.warning(
-            "sigma-cli not available; Sigma rules will generate but not auto-deploy"
-        )
+        log.warning(unavailable_msg)
     except subprocess.TimeoutExpired:
-        log.warning(
-            "sigma-cli not available; Sigma rules will generate but not auto-deploy"
-        )
+        log.warning(unavailable_msg)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/templates/cluster_detail.html
+++ b/agent/templates/cluster_detail.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="htmx-config" content='{"allowEval":false,"allowScriptTags":false}'>
   <title>Cluster {{ cluster.id[:8] }} — Shaferhund</title>
   <script src="/static/htmx-1.9.12.min.js"></script>
   <style>

--- a/agent/templates/deploy_events.html
+++ b/agent/templates/deploy_events.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="htmx-config" content='{"allowEval":false,"allowScriptTags":false}'>
   <title>Deploy Events — Shaferhund</title>
   <script src="/static/htmx-1.9.12.min.js"></script>
   <style>

--- a/agent/templates/index.html
+++ b/agent/templates/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="htmx-config" content='{"allowEval":false,"allowScriptTags":false}'>
   <title>Shaferhund — Alert Triage</title>
   <script src="/static/htmx-1.9.12.min.js"></script>
   <style>

--- a/compose.yaml
+++ b/compose.yaml
@@ -128,7 +128,11 @@ services:
       wazuh.manager:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      # Bind the host port to loopback by default. The app accepts
+      # unauthenticated single-mode requests when SHAFERHUND_TOKEN is unset,
+      # so publishing 8000 on every host interface would bypass the intended
+      # localhost-only safety boundary.
+      - "127.0.0.1:8000:8000"
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - ALERTS_FILE=/var/ossec/logs/alerts/alerts.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-fastapi==0.115.5
+fastapi==0.124.2
+# FastAPI 0.124 allows Starlette 0.40-0.50; pin the lower bound above
+# CVE-2025-54121 and CVE-2025-62727 affected releases.
+starlette>=0.49.1,<0.51.0
 uvicorn[standard]==0.32.1
 anthropic==0.40.0
 pydantic-settings==2.6.1
@@ -10,8 +13,9 @@ pysigma>=1.2.0
 # sigma-cli: CLI wrapper for pySigma rule conversion.
 # pysigma-backend-wazuh does not exist on PyPI; the Wazuh backend is
 # installed at container build time via `sigma plugin install wazuh`
-# (see Dockerfile).  sigma-cli==1.0.4 is the last stable 1.x release.
-sigma-cli==1.0.4
+# (see Dockerfile).  1.x depends on pysigma<0.12 and conflicts with the
+# pysigma>=1.2 parser API used by the app/tests, so keep this on 3.x.
+sigma-cli==3.0.2
 pytest==9.0.3
 pytest-asyncio==1.3.0
 httpx==0.28.1

--- a/tests/test_lookup_cloud_identity.py
+++ b/tests/test_lookup_cloud_identity.py
@@ -208,11 +208,18 @@ def test_handler_aggregates_events_for_principal():
     alice = "arn:aws:iam::123:user/alice"
     bob = "arn:aws:iam::123:user/bob"
 
-    _seed_event(conn, alice, src_ip="10.0.0.1", event_name="DescribeInstances", event_time="2026-04-25T01:00:00Z")
-    _seed_event(conn, alice, src_ip="10.0.0.2", event_name="ListBuckets",        event_time="2026-04-25T02:00:00Z")
-    _seed_event(conn, alice, src_ip="10.0.0.3", event_name="GetObject",          event_time="2026-04-25T03:00:00Z")
-    _seed_event(conn, bob,   src_ip="10.1.0.1", event_name="CreateUser",         event_time="2026-04-25T01:30:00Z")
-    _seed_event(conn, bob,   src_ip="10.1.0.2", event_name="DeleteUser",         event_time="2026-04-25T02:30:00Z")
+    # Relative timestamps (1–5h ago) so the test is not time-bombed: a
+    # hardcoded calendar date would fall outside the default ``lookback_hours``
+    # window once enough wall-clock time passes after the test was written.
+    now = datetime.now(timezone.utc)
+    def _ago(hours: int) -> str:
+        return (now - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    _seed_event(conn, alice, src_ip="10.0.0.1", event_name="DescribeInstances", event_time=_ago(5))
+    _seed_event(conn, alice, src_ip="10.0.0.2", event_name="ListBuckets",        event_time=_ago(4))
+    _seed_event(conn, alice, src_ip="10.0.0.3", event_name="GetObject",          event_time=_ago(3))
+    _seed_event(conn, bob,   src_ip="10.1.0.1", event_name="CreateUser",         event_time=_ago(4))
+    _seed_event(conn, bob,   src_ip="10.1.0.2", event_name="DeleteUser",         event_time=_ago(3))
 
     result_str = _handle_lookup_cloud_identity(
         {"principal_arn": alice, "lookback_hours": 168},

--- a/tests/test_sigmac.py
+++ b/tests/test_sigmac.py
@@ -192,23 +192,24 @@ def test_convert_raises_on_invalid_yaml():
 # ---------------------------------------------------------------------------
 
 
-def _sigma_on_path() -> bool:
-    """Return True if sigma-cli is available."""
+def _sigma_wazuh_backend_available() -> bool:
+    """Return True if sigma-cli can convert with the Wazuh backend."""
     try:
-        subprocess.run(
-            ["sigma", "--version"],
+        result = subprocess.run(
+            ["sigma", "convert", "-t", "wazuh"],
+            input=MINIMAL_SIGMA_YAML,
             capture_output=True,
             text=True,
             timeout=5,
         )
-        return True
+        return result.returncode == 0 and bool(result.stdout.strip())
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
 
 
 @pytest.mark.skipif(
-    not _sigma_on_path(),
-    reason="sigma-cli not installed in this environment",
+    not _sigma_wazuh_backend_available(),
+    reason="sigma-cli Wazuh backend is not installed in this environment",
 )
 def test_convert_real_invocation_happy_path(tmp_path):
     """Real sigma-cli invocation: verifies the subprocess contract end-to-end.

--- a/tests/test_sigmac_probe.py
+++ b/tests/test_sigmac_probe.py
@@ -84,21 +84,50 @@ def _make_metrics_client(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_probe_sets_available_true_on_success():
-    """Successful sigma --version → sigmac_available=True, sigmac_version populated."""
+    """Both ``sigma --version`` and ``sigma convert -t wazuh`` succeed →
+    sigmac_available=True, sigmac_version populated (DEC-DEPS-001).
+    """
     settings = _fresh_settings()
-    mock_result = _make_completed_process(0, "sigma-cli, version 1.0.4\n")
+    version_result = _make_completed_process(0, "sigma-cli, version 3.0.2\n")
+    backend_result = _make_completed_process(
+        0, "<group name='probe'><rule id='100100'/></group>\n"
+    )
 
-    with patch("agent.main.subprocess.run", return_value=mock_result) as mock_run:
+    with patch(
+        "agent.main.subprocess.run",
+        side_effect=[version_result, backend_result],
+    ) as mock_run:
         _probe_sigmac(settings)
 
-    mock_run.assert_called_once_with(
-        ["sigma", "--version"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
+    assert mock_run.call_count == 2
+    first_call, second_call = mock_run.call_args_list
+    assert first_call.args[0] == ["sigma", "--version"]
+    assert second_call.args[0] == ["sigma", "convert", "-t", "wazuh"]
     assert settings.sigmac_available is True
-    assert settings.sigmac_version == "sigma-cli, version 1.0.4"
+    assert settings.sigmac_version == "sigma-cli, version 3.0.2"
+
+
+def test_probe_sets_available_false_when_wazuh_backend_missing(caplog):
+    """``sigma --version`` succeeds but ``sigma convert -t wazuh`` errors →
+    sigmac_available=False, one WARNING citing the missing backend
+    (DEC-DEPS-001: upstream sigma-cli 3.x dropped the wazuh plugin).
+    """
+    settings = _fresh_settings()
+    version_result = _make_completed_process(0, "sigma-cli, version 3.0.2\n")
+    backend_result = _make_completed_process(2, "")  # Click "invalid --target"
+
+    with caplog.at_level(logging.WARNING, logger="agent.main"):
+        with patch(
+            "agent.main.subprocess.run",
+            side_effect=[version_result, backend_result],
+        ):
+            _probe_sigmac(settings)
+
+    assert settings.sigmac_available is False
+    assert settings.sigmac_version is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "wazuh backend" in warnings[0].message
 
 
 def test_probe_sets_available_false_on_filenotfound(caplog):


### PR DESCRIPTION
## Summary

Finishes the security hardening batch that was sitting uncommitted on `main` since the Phase 6 wrap (`f13d586`). Six concerns, one squash-merge:

1. **htmx XSS hardening** — `agent/templates/{cluster_detail,deploy_events,index}.html` now carry `<meta name="htmx-config" content='{"allowEval":false,"allowScriptTags":false}'>`. Defense-in-depth for the dashboard surface — htmx by default permits inline `<script>` execution from swapped fragments, which is an XSS amplifier even on trusted templates.

2. **Loopback-only port bind** — `compose.yaml` now binds `127.0.0.1:8000:8000` instead of `8000:8000`. The app accepts unauthenticated requests in `SHAFERHUND_AUTH_MODE=single` when `SHAFERHUND_TOKEN` is unset (DEC-COMPAT-P6-001), so publishing port 8000 on every host interface bypassed the intended localhost-only boundary.

3. **Starlette CVE pin** — `requirements.txt` now requires `starlette>=0.49.1,<0.51.0` (above CVE-2025-54121 and CVE-2025-62727 fixed releases). FastAPI bumped `0.115.5 → 0.124.2` to clear the dependency range.

4. **sigma-cli 1.x → 3.x** — `requirements.txt` pins `sigma-cli==3.0.2`. The 1.x line depends on `pysigma<0.12` which conflicts with the `pysigma>=1.2` parser API used by `agent/orchestrator.py::_check_sigma_syntax`.

5. **Honest sigma probe** (**DEC-DEPS-001** — see below) — `agent/main.py::_probe_sigmac` now runs both `sigma --version` **and** `sigma convert -t wazuh` against a minimal Sigma fixture, only flipping `settings.sigmac_available=True` if both succeed. `tests/test_sigmac.py` already used this predicate; the production probe now matches.

6. **Time-bomb test fix** — `tests/test_lookup_cloud_identity.py::test_handler_aggregates_events_for_principal` was seeding events at hardcoded `2026-04-25T...` with a 168h lookback. Replaced with relative `datetime.now(UTC) - timedelta(hours=N)` to match the pattern the rest of the file already uses.

## DEC-DEPS-001 (new — recorded here pending MASTER_PLAN.md merge)

| Field | Value |
|-------|-------|
| **Title** | sigma-cli pinned to 3.x; upstream wazuh backend unavailable until restoration |
| **Status** | accepted |

**Rationale:** sigma-cli 3.x dropped the upstream \`wazuh\` plugin from its plugin registry (\`sigma plugin list --plugin-type backend\` returns no \`wazuh\` entry). The plugin is also not published on PyPI (\`pysigma-backend-wazuh\` → \`no matching distribution\`). Sigma → Wazuh runtime conversion is consequently unavailable in this deployment; \`_probe_sigmac\` now correctly reports \`sigmac_available=False\`, the policy gate refuses Sigma auto-deploy attempts, and the dashboard reflects the degraded state. Sigma rule **generation** continues to work (the Anthropic-call path is unaffected, pysigma \`SigmaCollection.from_yaml\` validates structurally), but generated Sigma rules accumulate in the \`rules\` table without a runtime deploy target. Restoring the wazuh backend (fork, vendor, or wait for upstream port to sigma-cli 3.x) is a Phase 7 candidate (REQ-P0-P7-XXX — to be enumerated in the Phase 7 charter PR that immediately follows this one).

## Verification

- \`.venv/bin/pytest -q --no-header\` → **593 passed, 2 skipped, 6 deselected, 0 failed** (vs Phase 6 baseline 594 / 1 / 6 / 0). The 1 net delta is the sigma-cli wazuh-backend test correctly skipping when the backend is missing.
- New test \`test_probe_sets_available_false_when_wazuh_backend_missing\` covers the post-fix probe behaviour.
- The starlette 0.50 \`TemplateResponse(name, {...})\` deprecation warning surfaces on 5 tests but is non-blocking; \`TemplateResponse(request, name, {...})\` refactor is a separate follow-up.

## Out of scope (follow-ups)

- \`TemplateResponse(request, name)\` refactor in \`agent/main.py:1023/1048/1082\` (warning-level, defer)
- Restore Sigma → Wazuh runtime via forked or vendored backend (Phase 7 candidate)
- Migrate to uv / poetry lockfile

## Files changed

\`\`\`
agent/main.py                          (+72 -28)  probe verifies wazuh backend; +_PROBE_SIGMA_YAML
agent/templates/cluster_detail.html    (+1)       htmx-config meta
agent/templates/deploy_events.html     (+1)       htmx-config meta
agent/templates/index.html             (+1)       htmx-config meta
compose.yaml                           (+5 -1)    127.0.0.1:8000:8000 with rationale comment
requirements.txt                       (+6 -2)    fastapi 0.124.2 + starlette CVE pin + sigma-cli 3.0.2
tests/test_lookup_cloud_identity.py    (+9 -5)    relative timestamps
tests/test_sigmac.py                   (+9 -8)    skip predicate verifies wazuh convert
tests/test_sigmac_probe.py             (+37 -8)   updated probe test + new wazuh-missing test
\`\`\`

## Next

Charter PR (\`docs/plan-phase-7-scope\`) follows immediately — Phase 7 will pick the pair that extends Phase 5/6 to multi-cloud + adversarial cloud-technique scoring, and will codify DEC-DEPS-001 in MASTER_PLAN.md alongside the existing decision tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)